### PR TITLE
fix: segfault on Python 3.14 in libei variadic function call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Segfault on Python 3.14 caused by missing `argtypes` on variadic `ei_seat_bind_capabilities` ctypes call
+
 ## [0.7.0] - 2026-03-29
 
 ### Added

--- a/src/kwin_mcp/input.py
+++ b/src/kwin_mcp/input.py
@@ -162,7 +162,8 @@ def _load_libei() -> ctypes.CDLL:
     lib.ei_seat_has_capability.argtypes = [ctypes.c_void_p, ctypes.c_uint]
     lib.ei_seat_ref.restype = ctypes.c_void_p
     lib.ei_seat_ref.argtypes = [ctypes.c_void_p]
-    # ei_seat_bind_capabilities is variadic, argtypes not set
+    lib.ei_seat_bind_capabilities.restype = None
+    lib.ei_seat_bind_capabilities.argtypes = [ctypes.c_void_p]  # variadic: fixed param only
 
     # Device functions
     lib.ei_event_get_device.restype = ctypes.c_void_p


### PR DESCRIPTION
## Summary

Set `argtypes` on `ei_seat_bind_capabilities` — a variadic C function
whose argtypes were intentionally left unset because ctypes historically
didn't require them. On Python 3.14 this causes a segfault (exit code
139) during session start, as ctypes misinterprets the variadic arguments
at the C ABI level without the fixed parameter declaration.

## Motivation

`uvx install kwin-mcp` does not respect `.python-version` — it uses
whatever Python satisfies `requires-python` (>=3.12). Users on systems
with Python 3.14 as default (e.g. Fedora 43) hit this crash immediately
on session start. The fix sets `argtypes` to just the fixed parameter
(the seat pointer); the variadic arguments at the call site are already
wrapped as ctypes instances and pass through correctly.

## How to Test

1. `uv python pin 3.14 && uv sync`
2. Revert the fix in `src/kwin_mcp/input.py`
3. `echo "session_start" | uv run python -m kwin_mcp.cli` → exit code 139 (SIGSEGV)
4. Restore the fix, re-run → session starts normally
5. `uv python pin 3.12 && uv sync` to restore

## Checklist

- [x] `uv run ruff check .` passes
- [x] `uv run ruff format --check .` passes
- [x] `uv run ty check` passes
- [x] CHANGELOG.md updated (if user-facing change)
- [x] README.md updated (if new tools or changed behavior)