### PR TITLE
Fix ctypes SIGSEGV in Python 3.14

### DIFF
--- a/src/kwin_mcp/input.py
+++ b/src/kwin_mcp/input.py
@@ -349,6 +349,7 @@ class EISClient:
         # Call variadic ei_seat_bind_capabilities(seat, cap1, ..., NULL)
         func = _libei.ei_seat_bind_capabilities
         func.restype = None
+        func.argtypes = [ctypes.c_void_p] + [ctypes.c_uint] * len(bind_list) + [ctypes.c_void_p]
         args: list[ctypes.c_uint | ctypes.c_void_p] = [ctypes.c_uint(c) for c in bind_list]
         args.append(ctypes.c_void_p(None))  # NULL sentinel
         func(seat, *args)


### PR DESCRIPTION
ei_seat_bind_capabilities needs argtypes defined to call with varargs. Unsure if it's a ctypes bug or not.

- [x] `uv run ruff check .` passes
- [x] `uv run ruff format --check .` passes
- [x] `uv run ty check` passes
- [ ] CHANGELOG.md updated (if user-facing change)
- [ ] README.md updated (if new tools or changed behavior)
