### PR TITLE
fix: use D-Bus auto-activation for AT-SPI bus in isolated sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Segfault on Python 3.14 caused by missing `argtypes` on variadic `ei_seat_bind_capabilities` ctypes call
+- `accessibility_tree`, `find_ui_elements`, `wait_for_element`, `list_windows`, and `focus_window` now work in isolated virtual sessions on Fedora, Debian, Ubuntu, and any other distro that installs the AT-SPI bus launcher outside `/usr/lib` (e.g. `/usr/libexec`). Instead of executing a hardcoded path, the AT-SPI bus is now brought up via D-Bus auto-activation (`gdbus call org.a11y.Bus.GetAddress`), which defers binary-path resolution to `dbus-daemon` and the distro-provided service file. The registry daemon is auto-activated transparently when apps first touch the a11y bus, so no manual bootstrap is required. Thanks to @davidselassie for reporting the Fedora failure in [#8](https://github.com/isac322/kwin-mcp/pull/8).
 
 ## [0.7.0] - 2026-03-29
 

--- a/src/kwin_mcp/session.py
+++ b/src/kwin_mcp/session.py
@@ -333,19 +333,32 @@ class Session:
         return f"""\
 echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS"
 
-# Ensure all child processes are cleaned up on exit
+# Ensure all child processes are cleaned up on exit.
+# The AT-SPI bus launcher and registryd are started via D-Bus
+# auto-activation below; they are terminated automatically when our
+# isolated session bus exits (dbus-run-session tears the bus down on
+# parent exit), so we only need to track KWin explicitly here.
 cleanup() {{
-    kill $KWIN_PID $AT_SPI_PID 2>/dev/null
-    wait $KWIN_PID $AT_SPI_PID 2>/dev/null
+    kill $KWIN_PID 2>/dev/null
+    wait $KWIN_PID 2>/dev/null
 }}
 trap cleanup EXIT TERM INT HUP
 
-# Start the AT-SPI accessibility bus.
-# ATSPI_DBUS_IMPLEMENTATION is set in _build_env() to force dbus-daemon
-# instead of dbus-broker (which reuses the host's AT-SPI bus).
-/usr/lib/at-spi-bus-launcher --launch-immediately &
-AT_SPI_PID=$!
-sleep 0.2
+# Bring up the AT-SPI accessibility bus via D-Bus auto-activation.
+# Calling org.a11y.Bus.GetAddress makes dbus-daemon resolve the
+# service file (/usr/share/dbus-1/services/org.a11y.Bus.service) and
+# exec the launcher at whatever path the current distro uses — Arch
+# /usr/lib, Fedora/Debian/Ubuntu /usr/libexec, Flatpak /app/libexec,
+# etc. Hardcoding a path breaks on everything except Arch.
+# ATSPI_DBUS_IMPLEMENTATION=dbus-daemon (set in _build_env) prevents
+# dbus-broker from sharing the host's a11y bus.
+# The registryd comes up on its own when apps first touch the a11y
+# bus, so no manual bootstrap is needed here.
+gdbus call --session \\
+    --dest=org.a11y.Bus \\
+    --object-path=/org/a11y/bus \\
+    --method=org.a11y.Bus.GetAddress >/dev/null 2>&1 || true
+sleep 0.3
 
 # Pre-set D-Bus activation environment BEFORE starting KWin.
 # When KWin triggers portal auto-activation, portal-kde will get


### PR DESCRIPTION
## Summary

Replace the hardcoded `/usr/lib/at-spi-bus-launcher` path with D-Bus auto-activation so that `accessibility_tree`, `find_ui_elements`, `wait_for_element`, `list_windows`, and `focus_window` work in isolated virtual sessions on all distros — not just Arch.

## Problem

`_build_wrapper_script()` in `session.py:346` currently launches the AT-SPI bus by execing a hardcoded path:

```sh
/usr/lib/at-spi-bus-launcher --launch-immediately &
```

This path is only correct on Arch/Manjaro. Upstream `at-spi2-core` has migrated to `/usr/libexec/`, so on the following platforms the AT-SPI bus **is never started**:

- Fedora (`/usr/libexec/at-spi-bus-launcher`)
- Debian sid, Ubuntu 24.04 (`noble`) and later (`/usr/libexec/at-spi-bus-launcher`)
- Flatpak runtimes (`/app/libexec/at-spi-bus-launcher`)

With no a11y bus, every subsequent `_run_atspi()` call crashes with "Couldn't connect to accessibility bus". The bug had been invisible because development happens on Arch, which still uses `/usr/lib/`.

## Fix — delegate path resolution to D-Bus auto-activation

Don't try to resolve the binary path in kwin-mcp. Let `dbus-daemon` do it:

```sh
gdbus call --session \
    --dest=org.a11y.Bus \
    --object-path=/org/a11y/bus \
    --method=org.a11y.Bus.GetAddress >/dev/null 2>&1 || true
```

`dbus-daemon` reads `/usr/share/dbus-1/services/org.a11y.Bus.service` and execs the launcher at whatever path the current distro's package actually installed it to. Path resolution becomes the packaging layer's responsibility, which is how AT-SPI is designed to bootstrap.

The registry daemon (`at-spi2-registryd`) also does not need to be started manually — it is auto-activated on first access to the a11y bus through the same mechanism.

### Incidental cleanup

- Remove `AT_SPI_PID` from the cleanup trap. Auto-activated processes are torn down when `dbus-run-session` closes the session bus, so no explicit `kill` is needed.
- Bump `sleep 0.2` → `sleep 0.3`. `gdbus call` returns as soon as the bus address reply arrives, which is slightly earlier than full launcher initialization.

## Relationship to #8

This PR is an alternative to #8, opened by @davidselassie after hitting the Fedora failure. #8 parses the `Exec=` line from the service file with `sed` and starts the launcher and registryd manually. The auto-activation approach here removes the need for the `IsEnabled` property flip, the `--use-gnome-session` workaround, and the manual registryd bootstrap — `dbus-daemon` picks all of that up from the same service files.

## Testing

1. Static checks:
   ```
   uv run ruff check .
   uv run ruff format --check .
   uv run ty check
   ```
2. CLI smoke test — `accessibility_tree` should return a real widget tree, not `"(no accessible applications found)"`:
   ```
   printf 'session_start app_command=kcalc\naccessibility_tree\nsession_stop\nquit\n' \
     | uv run kwin-mcp-cli
   ```

Verified locally on Arch (`/usr/lib/`). Cross-distro verification (Fedora in particular) is welcome.

## Checklist

- [x] `uv run ruff check .` passes
- [x] `uv run ruff format --check .` passes
- [x] `uv run ty check` passes
- [x] CHANGELOG.md updated
- [x] README.md updated — N/A, no new tools or changed behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)