### PR TITLE
feat: bundle plugins for Claude Code and OpenCode

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://claude.ai/schemas/marketplace.json",
+  "name": "kwin-mcp",
+  "owner": {
+    "name": "Byeonghoon Yoo",
+    "email": "bhyoo@bhyoo.com",
+    "url": "https://github.com/isac322"
+  },
+  "metadata": {
+    "description": "kwin-mcp marketplace — MCP server and skill for Linux KDE Plasma 6 Wayland desktop GUI automation (virtual sessions for headless testing, live sessions for real-desktop / container / kiosk control).",
+    "version": "0.7.0",
+    "pluginRoot": "./integrations"
+  },
+  "plugins": [
+    {
+      "name": "kwin-mcp",
+      "source": "./claude-code",
+      "version": "0.7.0",
+      "description": "Bundles the kwin-mcp MCP server (uvx kwin-mcp) plus the kwin-desktop-automation skill that teaches session-mode selection, the observe-act-verify loop, US-QWERTY vs Unicode typing, and platform pitfalls (surface-local coordinates, QMenu invisibility, EIS edge limits, clipboard opt-in).",
+      "category": "automation",
+      "keywords": [
+        "mcp",
+        "kwin",
+        "kde",
+        "plasma",
+        "wayland",
+        "gui-automation",
+        "desktop-automation",
+        "linux",
+        "ai-agents",
+        "accessibility",
+        "at-spi2",
+        "libei",
+        "headless-testing",
+        "live-desktop"
+      ],
+      "license": "MIT",
+      "homepage": "https://github.com/isac322/kwin-mcp",
+      "repository": "https://github.com/isac322/kwin-mcp",
+      "author": {
+        "name": "Byeonghoon Yoo",
+        "email": "bhyoo@bhyoo.com"
+      }
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ wheels/
 
 # Virtual environments
 .venv
+
+# Local OpenCode plugin testing (symlink to integrations/opencode/plugin)
+.opencode/
+

--- a/README.md
+++ b/README.md
@@ -96,6 +96,28 @@ Claude Code will autonomously start an isolated session, launch the app, read th
 
 ## Configuration
 
+### Recommended: install as a plugin
+
+The fastest way to wire kwin-mcp into your editor is to install one of the bundled plugins. Each plugin auto-registers the MCP server **and** ships the `kwin-desktop-automation` skill, which teaches the agent which tool to call when (session-mode selection, the observe → act → verify loop, US-QWERTY vs Unicode typing, AT-SPI2 surface-local coordinates, and other platform pitfalls).
+
+**Claude Code** — install the plugin from the marketplace:
+
+```text
+/plugin marketplace add isac322/kwin-mcp
+/plugin install kwin-mcp@kwin-mcp
+```
+
+**OpenCode** — add the npm plugin to your `opencode.json`:
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["@isac322/kwin-mcp-opencode"]
+}
+```
+
+For the full integration guide (manual fallback, customising the skill, troubleshooting), see [docs/ai-agent-integration.md](docs/ai-agent-integration.md).
+
 ### Claude Code
 
 Add to your project's `.mcp.json`:

--- a/docs/ai-agent-integration.md
+++ b/docs/ai-agent-integration.md
@@ -1,0 +1,116 @@
+# AI Agent Integration
+
+Three onboarding paths for `kwin-mcp`. Pick the one that matches your editor.
+
+## Why use the integrations?
+
+`kwin-mcp` exposes **30 MCP tools**. Without context, an AI agent often calls them in the wrong order — skipping `session_start`, mixing up `keyboard_type` vs `keyboard_type_unicode`, ignoring the AT-SPI2 surface-local coordinate system, and so on.
+
+Each integration package bundles:
+
+- The MCP server config, so you don't have to edit JSON by hand.
+- The `kwin-desktop-automation` **skill**, which loads operational guidance into the agent only when desktop-automation work is requested. The skill teaches:
+  1. **Which session mode to pick** — `session_start` for virtual / isolated testing, `session_connect` for live desktop / container / kiosk.
+  2. **The observe → act → verify loop**, with observation tools ordered by cost (`list_windows` < `accessibility_tree` < `find_ui_elements` < `wait_for_element` < `screenshot`).
+  3. **Pitfalls** — US-QWERTY-only `keyboard_type`, Unicode via `keyboard_type_unicode`, clipboard opt-in on virtual sessions, AT-SPI2 surface-local coordinates, QMenu invisibility, screen-edge triggers ignored by EIS.
+  4. **Cleanup** — always call `session_stop`; `keep_screenshots=true` and `keep_home=true` leak `/tmp` directories.
+
+## Scenario A — Claude Code only
+
+```text
+/plugin marketplace add isac322/kwin-mcp
+/plugin install kwin-mcp@kwin-mcp
+```
+
+That installs:
+
+- `kwin-mcp` MCP server (`uvx kwin-mcp`) registered for the current project.
+- `kwin-desktop-automation` skill, auto-loaded by Claude Code when the user asks for desktop / GUI / Wayland / KDE automation.
+
+If you prefer to skip the plugin and configure manually, see [README — Configuration](../README.md#configuration).
+
+## Scenario B — OpenCode only
+
+In your project's `opencode.json` (or `~/.config/opencode/opencode.json` for global):
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["@isac322/kwin-mcp-opencode"]
+}
+```
+
+On the next OpenCode startup the plugin's `config` hook:
+
+1. Injects the `kwin-mcp` MCP server (`uvx kwin-mcp`) into OpenCode's runtime config — equivalent to writing a `mcp.kwin-mcp` block into `opencode.json` by hand, but added programmatically (idempotent — re-runs are no-ops).
+2. Adds the bundled skill directory to `skills.paths` so OpenCode discovers `kwin-desktop-automation` SKILL.md shipped inside the npm package.
+
+OpenCode loads the skill lazily via the `skill` tool whenever the agent decides desktop automation is in scope. The plugin never copies files outside the npm package, so `npm uninstall @isac322/kwin-mcp-opencode` cleanly removes both registrations on next startup.
+
+### Manual fallback
+
+If the plugin's `config` hook ever fails to inject the MCP server (e.g. OpenCode's plugin contract changed), drop the contents of [`integrations/opencode/opencode.json.example`](../integrations/opencode/opencode.json.example) into your `opencode.json`:
+
+```jsonc
+{
+  "mcp": {
+    "kwin-mcp": {
+      "type": "local",
+      "command": ["uvx", "kwin-mcp"],
+      "enabled": true
+    }
+  }
+}
+```
+
+## Scenario C — Both Claude Code and OpenCode
+
+Do both Scenario A and Scenario B. Each integration is self-contained — installing one does not affect the other.
+
+**Both plugins ship the same host-agnostic SKILL.md.** The Claude Code plugin keeps its copy under [`integrations/claude-code/skills/kwin-desktop-automation/SKILL.md`](../integrations/claude-code/skills/kwin-desktop-automation/SKILL.md) (the source of truth); the OpenCode plugin's `npm run build` copies that file into [`integrations/opencode/plugin/skill/kwin-desktop-automation/SKILL.md`](../integrations/opencode/plugin/skill/kwin-desktop-automation/SKILL.md) before packaging. The skill body uses bare tool names (`session_start`, `screenshot`, ...) — each host adds its own prefix (`mcp__kwin-mcp__*` in Claude Code, `kwin-mcp_*` in OpenCode) when exposing the tools to the model.
+
+## Customising the skill
+
+Both plugins ship the same SKILL.md content; the Claude Code plugin's copy is the source of truth, and the OpenCode plugin re-copies it on every build. To override either for yourself:
+
+- **Claude Code**: copy the shipped file to `~/.claude/skills/kwin-desktop-automation/SKILL.md` (personal scope) or `<project>/.claude/skills/kwin-desktop-automation/SKILL.md` (project scope). Personal and project skills override plugin skills with the same name.
+- **OpenCode**: drop your own `SKILL.md` under `~/.config/opencode/skills/<name>/SKILL.md` (or `<project>/.opencode/skills/`). The plugin never writes into your skill directories — the shipped SKILL.md is read-only inside the npm package, served via `skills.paths` injection. OpenCode keys skills by their frontmatter `name`, so reuse `kwin-desktop-automation` to override the shipped one, or pick a unique name (e.g. `kwin-desktop-automation-custom`) to keep both.
+
+## Troubleshooting
+
+### `uvx: command not found`
+
+The MCP launch command is `uvx kwin-mcp`. Install [`uv`](https://docs.astral.sh/uv/) first:
+
+```bash
+# Arch / Manjaro
+sudo pacman -S uv
+
+# Fedora
+sudo dnf install uv
+```
+
+If you prefer a global install of `kwin-mcp` itself, run `uv tool install kwin-mcp` and replace `"command": ["uvx", "kwin-mcp"]` with `"command": ["kwin-mcp"]` in the OpenCode config (or the equivalent for Claude Code's `.mcp.json`).
+
+### Plugin installs but the agent ignores it
+
+The skill is only loaded when the agent decides it's relevant. Make your prompt mention desktop / GUI / Wayland / KDE work explicitly (for example, *"using kwin-mcp, launch kcalc and..."*). Both Claude Code and OpenCode index the skill's `description` and `when_to_use` frontmatter for this trigger decision.
+
+### `session_start` works but `accessibility_tree` returns nothing
+
+The launched app may not yet have registered with AT-SPI2. Add a `wait_for_element` poll after launch, or set `expected_states=["active"]`. For some Qt apps, set `QT_ACCESSIBILITY=1` via the `env` argument to `session_start` or `launch_app`.
+
+### Live session: input lands on the host instead of the target window
+
+Make sure the target window is focused before injecting input. Call `focus_window(app_name=...)` first. EIS injects globally into the compositor, so whichever window currently has keyboard focus receives the event.
+
+### Container / kiosk: `session_connect` cannot reach the live KWin
+
+`session_connect` needs `DBUS_SESSION_BUS_ADDRESS` and `WAYLAND_DISPLAY` of the live KWin instance. In a container, mount the host's `XDG_RUNTIME_DIR` socket directory and pass these env vars through. See the README's [*Live Desktop Collaboration*](../README.md#live-desktop-collaboration) use case for the full setup.
+
+## See also
+
+- [README — Configuration](../README.md#configuration) — manual `.mcp.json` config
+- [README — Limitations](../README.md#limitations) — full pitfall list
+- [`integrations/claude-code/`](../integrations/claude-code/) — Claude Code plugin source
+- [`integrations/opencode/plugin/`](../integrations/opencode/plugin/) — OpenCode plugin source

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://claude.ai/schemas/plugin.json",
+  "name": "kwin-mcp",
+  "version": "0.7.0",
+  "description": "MCP server + skill for Linux KDE Plasma 6 Wayland GUI automation. Provides 30 MCP tools (mouse, keyboard, touch, clipboard, screenshot, AT-SPI2 accessibility tree, window mgmt, D-Bus passthrough) plus the kwin-desktop-automation skill that guides session-mode selection, observation/action sequencing, and platform pitfalls.",
+  "author": {
+    "name": "Byeonghoon Yoo",
+    "email": "bhyoo@bhyoo.com",
+    "url": "https://github.com/isac322"
+  },
+  "homepage": "https://github.com/isac322/kwin-mcp",
+  "repository": "https://github.com/isac322/kwin-mcp",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "kwin",
+    "kde",
+    "plasma",
+    "wayland",
+    "gui-automation",
+    "desktop-automation",
+    "linux",
+    "ai-agents",
+    "accessibility",
+    "at-spi2",
+    "libei",
+    "headless-testing",
+    "live-desktop",
+    "claude-code"
+  ]
+}

--- a/integrations/claude-code/.mcp.json
+++ b/integrations/claude-code/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "kwin-mcp": {
+      "command": "uvx",
+      "args": ["kwin-mcp"]
+    }
+  }
+}

--- a/integrations/claude-code/skills/kwin-desktop-automation/SKILL.md
+++ b/integrations/claude-code/skills/kwin-desktop-automation/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: kwin-desktop-automation
+description: Use when the user asks to launch, click, type, screenshot, or otherwise drive a Linux KDE Plasma / Wayland desktop app through the kwin-mcp MCP server. Trigger when kwin-mcp tools are available and the task involves desktop GUI automation, end-to-end GUI testing, kiosk / embedded device control, or live KDE Plasma session interaction. Teaches session-mode selection (virtual vs live), the observe-act-verify loop, AT-SPI2 vs screenshot tradeoffs, US-QWERTY vs Unicode typing, and platform pitfalls (surface-local coordinates, QMenu invisibility, EIS edge limits, clipboard opt-in).
+---
+
+# kwin-desktop-automation
+
+Drive Linux KDE Plasma 6 Wayland desktops through the `kwin-mcp` MCP server. The MCP server provides 30 capabilities; this skill provides the operational discipline to use them efficiently, in the right order, and without falling into platform-specific traps.
+
+## When to apply
+
+Activate this skill whenever the user wants to:
+
+- Launch, click, type, or screenshot any KDE / Qt / GTK / Electron app on Wayland.
+- Run end-to-end GUI tests in a headless / virtual KWin session (CI, regression, reproducibility).
+- Drive a live KDE Plasma session (their actual desktop) or a KWin instance inside a container.
+- Inspect or operate a kiosk / embedded Linux device exposing AT-SPI2.
+
+If no kwin-mcp tools are available, this skill does not apply.
+
+## 1. Pick the session mode
+
+Every other tool requires a session. Two mutually exclusive modes:
+
+**Virtual — `session_start`**
+Opens an isolated `dbus-run-session + kwin_wayland --virtual` compositor. Nothing reaches the host display. Use when the user says "test", "headless", "CI", "isolated", or names a specific app to launch fresh.
+
+Useful arguments:
+- `app_command="..."` — launch the target app inside the session.
+- `enable_clipboard=true` — required for `clipboard_get` / `clipboard_set` and the Unicode-via-clipboard fallback. Off by default because `wl-copy` can hang on a freshly minted bus.
+- `keep_screenshots=true` — preserves PNGs in `/tmp/kwin-mcp-screenshots-*` after `session_stop` (delete the directory yourself when done).
+- `isolate_home=true` — temp HOME with isolated XDG dirs; keeps host configuration untouched.
+
+**Live — `session_connect`**
+Attaches to an already-running KWin: the user's real desktop, or a KWin running inside a container / kiosk / embedded device. Use when the user says "my", "current", "this window", "what I'm looking at", "container", "kiosk", or "live". Defaults to `$DBUS_SESSION_BUS_ADDRESS` and `$WAYLAND_DISPLAY`; clipboard is always enabled. `session_stop` only disconnects — it never kills the live KWin or its apps.
+
+If the kwin-mcp server was launched with `--default-live-session`, the descriptions of `session_start` and `session_connect` swap roles; in that mode `session_connect` is the default.
+
+End every successful turn that opened a session with `session_stop`. Virtual sessions leak kwin processes otherwise; live sessions just disconnect.
+
+## 2. Observe → Act → Verify
+
+Each interaction is three steps. Cheap observation **before** action prevents acting on an unfocused window or stale UI.
+
+**Observation tools, cheapest first:**
+
+1. `list_windows` — window titles + active/focused markers. Free.
+2. `accessibility_tree` — full AT-SPI2 widget tree. Always pass `app_name=` and/or `role=` (e.g. `"button"`, `"check box"`) and/or `max_depth=` to keep it small. Don't fetch the whole tree just to find one button.
+3. `find_ui_elements` — query by name/role/states. Use this when you know what you are looking for. `query=""` + `states=["focused"]` answers "what currently has focus?".
+4. `wait_for_element` — same matching as `find_ui_elements` but polls until the element appears (or `timeout_ms` elapses). Use after launching an app or after any click that triggers async UI.
+5. `screenshot` — last resort for visual inspection or when AT-SPI2 fails to expose an element (see Pitfalls).
+
+Pick the cheapest tool that answers the question. Do not start with `screenshot` if `find_ui_elements("Save")` would suffice.
+
+**Action tools:**
+
+- Click coordinates returned by `find_ui_elements` / `accessibility_tree` directly with `mouse_click`.
+- `keyboard_type` is **ASCII / US-QWERTY only**. It maps characters to evdev keycodes; non-ASCII silently breaks.
+- `keyboard_type_unicode` for Korean / CJK / emoji / any non-ASCII. Internally uses `wtype` first, falls back to `wl-copy` + Ctrl+V. Requires `wtype` or `wl-clipboard` installed.
+
+Branch typing by string content — never assume the input is ASCII.
+
+**Verify after every meaningful action.** Typical pattern:
+
+1. `find_ui_elements(query="OK", states=["enabled"])` — locate.
+2. `mouse_click(x, y)` — act.
+3. `wait_for_element(query="Settings saved", timeout_ms=3000)` — confirm.
+
+For animation-heavy or transient UI, pass `screenshot_after_ms=[0, 100, 300]` to a single action call instead of three round-trips — kwin-mcp captures frames server-side via the fast ScreenShot2 D-Bus interface (~30–70 ms per frame).
+
+## 3. Pitfalls
+
+These are properties of the Wayland / AT-SPI2 / EIS stack, not bugs. Know them or get burned.
+
+- **`keyboard_type` is US QWERTY only.** Non-ASCII text must go through `keyboard_type_unicode`. Always check the input.
+- **Clipboard is opt-in on virtual sessions.** Pass `enable_clipboard=true` to `session_start` AND ensure `wl-clipboard` is installed. Live sessions always have clipboard.
+- **AT-SPI2 coordinates are surface-local on Wayland.** Each app's coordinates are relative to its own window's top-left, not the virtual screen — Wayland clients do not know their global position by design. Single-window scenarios are fine. For multi-window layouts, cross-reference with `screenshot` to disambiguate.
+- **QMenu and native context menus may be invisible to AT-SPI2.** Qt's AT-SPI2 bridge has incomplete popup-menu support on Wayland. Workaround: take a `screenshot`, locate the menu item visually, click by coordinates.
+- **Screen edge triggers (auto-hide panels, layer-shell strips) ignore EIS pointer events.** Use `dbus_call` to invoke KWin scripting or a keyboard shortcut instead of trying to hover the edge.
+- **Live sessions inside containers need Wayland + D-Bus mounted in.** Symptom: `session_connect` fails with "no Wayland display" or "no session bus". The user must mount `$XDG_RUNTIME_DIR/wayland-*` and propagate `DBUS_SESSION_BUS_ADDRESS` into the container.
+- **Touch is EIS-emulated, not from a real touchscreen.** Most apps handle this correctly, but a few may behave differently from a physical touch device.
+
+## 4. Cleanup
+
+- Always call `session_stop` once the task is complete, even if a step errored.
+- If `keep_screenshots=true` was used, `/tmp/kwin-mcp-screenshots-*` survives `session_stop`. Delete it explicitly when no longer needed.
+- If `isolate_home=true` + `keep_home=true` were both used, the temp HOME under `/tmp/` also survives — delete it manually.
+
+## Quick recipes
+
+**"Screenshot my desktop"** (live):
+1. `session_connect()`
+2. `screenshot()` → report the file path.
+3. `session_stop()`.
+
+**"Click the Save button in kate"** (virtual):
+1. `session_start(app_command="kate")`
+2. `wait_for_element(query="Save", app_name="kate", timeout_ms=5000)`
+3. `mouse_click(x, y)` using coords from step 2.
+4. `wait_for_element(query="Save File", timeout_ms=3000)` to confirm the dialog appeared.
+5. `session_stop()`.
+
+**"Type 안녕하세요 into the active text field"**:
+1. (Session already open.)
+2. `keyboard_type_unicode(text="안녕하세요")` — never `keyboard_type`; it would silently drop the characters.
+
+**"Find what currently has focus"**:
+1. `find_ui_elements(query="", states=["focused"])` — empty query is allowed when filtering by state.

--- a/integrations/opencode/opencode.json.example
+++ b/integrations/opencode/opencode.json.example
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "kwin-mcp": {
+      "type": "local",
+      "command": ["uvx", "kwin-mcp"],
+      "enabled": true
+    }
+  }
+}

--- a/integrations/opencode/plugin/.gitignore
+++ b/integrations/opencode/plugin/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+package-lock.json

--- a/integrations/opencode/plugin/.swcrc
+++ b/integrations/opencode/plugin/.swcrc
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://swc.rs/schema.json",
+  "jsc": {
+    "parser": { "syntax": "typescript" },
+    "target": "es2024"
+  },
+  "module": { "type": "es6" },
+  "sourceMaps": true
+}

--- a/integrations/opencode/plugin/LICENSE
+++ b/integrations/opencode/plugin/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Byeonghoon Yoo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/integrations/opencode/plugin/README.md
+++ b/integrations/opencode/plugin/README.md
@@ -1,0 +1,100 @@
+# @isac322/kwin-mcp-opencode
+
+OpenCode plugin for [`kwin-mcp`](https://github.com/isac322/kwin-mcp) — the MCP server for Linux desktop GUI automation on KDE Plasma 6 Wayland.
+
+On every OpenCode backend startup the plugin's `config` hook:
+
+1. **Registers the `kwin-mcp` MCP server** by injecting `mcp.kwin-mcp = { type: "local", command: ["uvx", "kwin-mcp"], enabled: true }` into the runtime config — equivalent to a static block in `opencode.json`, but added programmatically so users do not have to edit config.
+2. **Adds the bundled skill directory to `skills.paths`** so OpenCode discovers the `kwin-desktop-automation` SKILL.md shipped inside the npm package. The skill teaches which kwin-mcp tool to call when, plus the platform pitfalls of Wayland / AT-SPI2 / EIS.
+
+Both steps are idempotent — re-running OpenCode is a no-op. The plugin never copies files outside the npm package, so `npm uninstall @isac322/kwin-mcp-opencode` cleanly removes both the MCP server registration and the skill on next startup.
+
+## Installation
+
+In your `opencode.json`:
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["@isac322/kwin-mcp-opencode"]
+}
+```
+
+OpenCode resolves the npm package and runs the plugin on every startup.
+
+The plugin assumes [`uvx`](https://docs.astral.sh/uv/) is on your `PATH` and uses `uvx kwin-mcp` to launch the MCP server. Install `uv` first:
+
+```bash
+# Arch / Manjaro
+sudo pacman -S uv
+
+# Fedora
+sudo dnf install uv
+
+# Ubuntu / Debian
+# see https://docs.astral.sh/uv/getting-started/installation/
+```
+
+You also need the kwin-mcp system dependencies (`kwin_wayland`, `at-spi2-core`, `spectacle`, `python-gobject`, `dbus-python`, optionally `wl-clipboard` and `wtype`). See [the kwin-mcp README](https://github.com/isac322/kwin-mcp#installing-system-dependencies) for distro-specific commands.
+
+## Manual fallback
+
+If the plugin's `config` hook ever fails to inject the MCP server (e.g. OpenCode's plugin contract changed), add a static block to `opencode.json`:
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "kwin-mcp": {
+      "type": "local",
+      "command": ["uvx", "kwin-mcp"],
+      "enabled": true
+    }
+  }
+}
+```
+
+A copy of this snippet ships at [`opencode.json.example`](https://github.com/isac322/kwin-mcp/blob/main/integrations/opencode/opencode.json.example).
+
+## What the skill teaches
+
+`kwin-desktop-automation` is a host-agnostic `SKILL.md` shipped inside this npm package. It uses bare tool names (`session_start`, `screenshot`, etc.) — OpenCode adds its own `kwin-mcp_` prefix when exposing the tools to the model, so the agent learns the actual tool symbols from OpenCode's tool list rather than from the skill body. (The same SKILL.md content is shared with the [Claude Code plugin](https://github.com/isac322/kwin-mcp/tree/main/integrations/claude-code); `npm run build` copies the source from `../../claude-code/skills/...` into this package's `skill/` directory before packaging.) The skill covers:
+
+1. **Session mode selection** — when to call `session_start` (virtual / isolated) vs `session_connect` (live / real desktop / container / kiosk).
+2. **The observe → act → verify loop** — observation tools ordered by cost (`list_windows` < `accessibility_tree` < `find_ui_elements` < `wait_for_element` < `screenshot`).
+3. **Pitfalls** — `keyboard_type` is US-QWERTY only (use `keyboard_type_unicode` for CJK), clipboard is opt-in on virtual sessions, AT-SPI2 coordinates are surface-local, QMenu can be invisible to AT-SPI2, screen-edge triggers ignore EIS pointer events, container live sessions need Wayland/D-Bus mounts.
+4. **Cleanup** — always `session_stop`; `keep_screenshots=true` and `keep_home=true` leak `/tmp` directories.
+
+## Customising the skill
+
+The shipped skill lives inside the npm package (read-only). To override or extend it without touching the package, drop your own `SKILL.md` into a directory OpenCode already scans:
+
+- Personal scope: `~/.claude/skills/<name>/SKILL.md` or `~/.config/opencode/skills/<name>/SKILL.md`
+- Project scope: `<project>/.claude/skills/<name>/SKILL.md` or `<project>/.opencode/skills/<name>/SKILL.md`
+
+OpenCode keys skills by their frontmatter `name`, so reuse `kwin-desktop-automation` to override the shipped one, or pick a unique name (e.g. `kwin-desktop-automation-custom`) to keep both alongside each other.
+
+## Uninstall
+
+`npm uninstall @isac322/kwin-mcp-opencode`, then restart OpenCode. Because the plugin never copies files outside the npm package, no manual cleanup is needed — both the MCP server registration and the skill drop out of the next runtime config automatically.
+
+## Building from source
+
+```bash
+cd integrations/opencode/plugin
+npm install
+npm run build  # copies SKILL.md from ../../claude-code/skills/, then swc compiles src/ → dist/index.js (no declaration emit)
+```
+
+The published npm tarball ships only `dist/`, `skill/`, `README.md`, and `LICENSE` — `src/` and `tsconfig.json` are dev-only.
+
+## Compatibility
+
+- OpenCode (anomalyco/opencode) v1.14+ — uses the canonical `Plugin` function contract from [`@opencode-ai/plugin`](https://www.npmjs.com/package/@opencode-ai/plugin) and the `config` hook.
+- Bun runtime (OpenCode runs plugins on Bun).
+- Build toolchain: [`swc`](https://swc.rs/) for transpile (`src/` → `dist/index.js`) and [`tsgo`](https://github.com/microsoft/typescript-go) (TypeScript v7 native preview, package `@typescript/native-preview`) for typecheck-only.
+- Linux with KDE Plasma 6 Wayland to actually run the MCP server.
+
+## License
+
+MIT — see [LICENSE](https://github.com/isac322/kwin-mcp/blob/main/LICENSE).

--- a/integrations/opencode/plugin/package.json
+++ b/integrations/opencode/plugin/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@isac322/kwin-mcp-opencode",
+  "version": "0.7.0",
+  "description": "OpenCode plugin for kwin-mcp — auto-registers the kwin-mcp MCP server (uvx kwin-mcp) and ships the kwin-desktop-automation skill on backend startup.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "exports": {
+    "./server": "./dist/index.js"
+  },
+  "files": [
+    "dist",
+    "skill",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build:skill": "mkdir -p skill/kwin-desktop-automation && cp ../../claude-code/skills/kwin-desktop-automation/SKILL.md skill/kwin-desktop-automation/SKILL.md",
+    "build:js": "swc src -d dist --strip-leading-paths",
+    "build": "npm run clean && npm run build:skill && npm run build:js",
+    "typecheck": "tsgo -p tsconfig.json",
+    "prepack": "npm run build"
+  },
+  "devDependencies": {
+    "@opencode-ai/plugin": "^1.14.31",
+    "@swc/cli": "^0.8.1",
+    "@swc/core": "^1.15.32",
+    "@types/node": "^25.6.0",
+    "@typescript/native-preview": "^7.0.0-dev.20260502.1"
+  },
+  "keywords": [
+    "opencode",
+    "opencode-plugin",
+    "kwin-mcp",
+    "mcp",
+    "model-context-protocol",
+    "kwin",
+    "kde",
+    "plasma",
+    "wayland",
+    "gui-automation",
+    "desktop-automation",
+    "linux",
+    "ai-agents",
+    "accessibility",
+    "at-spi2"
+  ],
+  "license": "MIT",
+  "author": "Byeonghoon Yoo <bhyoo@bhyoo.com>",
+  "homepage": "https://github.com/isac322/kwin-mcp/tree/main/integrations/opencode/plugin",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/isac322/kwin-mcp.git",
+    "directory": "integrations/opencode/plugin"
+  },
+  "bugs": {
+    "url": "https://github.com/isac322/kwin-mcp/issues"
+  }
+}

--- a/integrations/opencode/plugin/skill/kwin-desktop-automation/SKILL.md
+++ b/integrations/opencode/plugin/skill/kwin-desktop-automation/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: kwin-desktop-automation
+description: Use when the user asks to launch, click, type, screenshot, or otherwise drive a Linux KDE Plasma / Wayland desktop app through the kwin-mcp MCP server. Trigger when kwin-mcp tools are available and the task involves desktop GUI automation, end-to-end GUI testing, kiosk / embedded device control, or live KDE Plasma session interaction. Teaches session-mode selection (virtual vs live), the observe-act-verify loop, AT-SPI2 vs screenshot tradeoffs, US-QWERTY vs Unicode typing, and platform pitfalls (surface-local coordinates, QMenu invisibility, EIS edge limits, clipboard opt-in).
+---
+
+# kwin-desktop-automation
+
+Drive Linux KDE Plasma 6 Wayland desktops through the `kwin-mcp` MCP server. The MCP server provides 30 capabilities; this skill provides the operational discipline to use them efficiently, in the right order, and without falling into platform-specific traps.
+
+## When to apply
+
+Activate this skill whenever the user wants to:
+
+- Launch, click, type, or screenshot any KDE / Qt / GTK / Electron app on Wayland.
+- Run end-to-end GUI tests in a headless / virtual KWin session (CI, regression, reproducibility).
+- Drive a live KDE Plasma session (their actual desktop) or a KWin instance inside a container.
+- Inspect or operate a kiosk / embedded Linux device exposing AT-SPI2.
+
+If no kwin-mcp tools are available, this skill does not apply.
+
+## 1. Pick the session mode
+
+Every other tool requires a session. Two mutually exclusive modes:
+
+**Virtual — `session_start`**
+Opens an isolated `dbus-run-session + kwin_wayland --virtual` compositor. Nothing reaches the host display. Use when the user says "test", "headless", "CI", "isolated", or names a specific app to launch fresh.
+
+Useful arguments:
+- `app_command="..."` — launch the target app inside the session.
+- `enable_clipboard=true` — required for `clipboard_get` / `clipboard_set` and the Unicode-via-clipboard fallback. Off by default because `wl-copy` can hang on a freshly minted bus.
+- `keep_screenshots=true` — preserves PNGs in `/tmp/kwin-mcp-screenshots-*` after `session_stop` (delete the directory yourself when done).
+- `isolate_home=true` — temp HOME with isolated XDG dirs; keeps host configuration untouched.
+
+**Live — `session_connect`**
+Attaches to an already-running KWin: the user's real desktop, or a KWin running inside a container / kiosk / embedded device. Use when the user says "my", "current", "this window", "what I'm looking at", "container", "kiosk", or "live". Defaults to `$DBUS_SESSION_BUS_ADDRESS` and `$WAYLAND_DISPLAY`; clipboard is always enabled. `session_stop` only disconnects — it never kills the live KWin or its apps.
+
+If the kwin-mcp server was launched with `--default-live-session`, the descriptions of `session_start` and `session_connect` swap roles; in that mode `session_connect` is the default.
+
+End every successful turn that opened a session with `session_stop`. Virtual sessions leak kwin processes otherwise; live sessions just disconnect.
+
+## 2. Observe → Act → Verify
+
+Each interaction is three steps. Cheap observation **before** action prevents acting on an unfocused window or stale UI.
+
+**Observation tools, cheapest first:**
+
+1. `list_windows` — window titles + active/focused markers. Free.
+2. `accessibility_tree` — full AT-SPI2 widget tree. Always pass `app_name=` and/or `role=` (e.g. `"button"`, `"check box"`) and/or `max_depth=` to keep it small. Don't fetch the whole tree just to find one button.
+3. `find_ui_elements` — query by name/role/states. Use this when you know what you are looking for. `query=""` + `states=["focused"]` answers "what currently has focus?".
+4. `wait_for_element` — same matching as `find_ui_elements` but polls until the element appears (or `timeout_ms` elapses). Use after launching an app or after any click that triggers async UI.
+5. `screenshot` — last resort for visual inspection or when AT-SPI2 fails to expose an element (see Pitfalls).
+
+Pick the cheapest tool that answers the question. Do not start with `screenshot` if `find_ui_elements("Save")` would suffice.
+
+**Action tools:**
+
+- Click coordinates returned by `find_ui_elements` / `accessibility_tree` directly with `mouse_click`.
+- `keyboard_type` is **ASCII / US-QWERTY only**. It maps characters to evdev keycodes; non-ASCII silently breaks.
+- `keyboard_type_unicode` for Korean / CJK / emoji / any non-ASCII. Internally uses `wtype` first, falls back to `wl-copy` + Ctrl+V. Requires `wtype` or `wl-clipboard` installed.
+
+Branch typing by string content — never assume the input is ASCII.
+
+**Verify after every meaningful action.** Typical pattern:
+
+1. `find_ui_elements(query="OK", states=["enabled"])` — locate.
+2. `mouse_click(x, y)` — act.
+3. `wait_for_element(query="Settings saved", timeout_ms=3000)` — confirm.
+
+For animation-heavy or transient UI, pass `screenshot_after_ms=[0, 100, 300]` to a single action call instead of three round-trips — kwin-mcp captures frames server-side via the fast ScreenShot2 D-Bus interface (~30–70 ms per frame).
+
+## 3. Pitfalls
+
+These are properties of the Wayland / AT-SPI2 / EIS stack, not bugs. Know them or get burned.
+
+- **`keyboard_type` is US QWERTY only.** Non-ASCII text must go through `keyboard_type_unicode`. Always check the input.
+- **Clipboard is opt-in on virtual sessions.** Pass `enable_clipboard=true` to `session_start` AND ensure `wl-clipboard` is installed. Live sessions always have clipboard.
+- **AT-SPI2 coordinates are surface-local on Wayland.** Each app's coordinates are relative to its own window's top-left, not the virtual screen — Wayland clients do not know their global position by design. Single-window scenarios are fine. For multi-window layouts, cross-reference with `screenshot` to disambiguate.
+- **QMenu and native context menus may be invisible to AT-SPI2.** Qt's AT-SPI2 bridge has incomplete popup-menu support on Wayland. Workaround: take a `screenshot`, locate the menu item visually, click by coordinates.
+- **Screen edge triggers (auto-hide panels, layer-shell strips) ignore EIS pointer events.** Use `dbus_call` to invoke KWin scripting or a keyboard shortcut instead of trying to hover the edge.
+- **Live sessions inside containers need Wayland + D-Bus mounted in.** Symptom: `session_connect` fails with "no Wayland display" or "no session bus". The user must mount `$XDG_RUNTIME_DIR/wayland-*` and propagate `DBUS_SESSION_BUS_ADDRESS` into the container.
+- **Touch is EIS-emulated, not from a real touchscreen.** Most apps handle this correctly, but a few may behave differently from a physical touch device.
+
+## 4. Cleanup
+
+- Always call `session_stop` once the task is complete, even if a step errored.
+- If `keep_screenshots=true` was used, `/tmp/kwin-mcp-screenshots-*` survives `session_stop`. Delete it explicitly when no longer needed.
+- If `isolate_home=true` + `keep_home=true` were both used, the temp HOME under `/tmp/` also survives — delete it manually.
+
+## Quick recipes
+
+**"Screenshot my desktop"** (live):
+1. `session_connect()`
+2. `screenshot()` → report the file path.
+3. `session_stop()`.
+
+**"Click the Save button in kate"** (virtual):
+1. `session_start(app_command="kate")`
+2. `wait_for_element(query="Save", app_name="kate", timeout_ms=5000)`
+3. `mouse_click(x, y)` using coords from step 2.
+4. `wait_for_element(query="Save File", timeout_ms=3000)` to confirm the dialog appeared.
+5. `session_stop()`.
+
+**"Type 안녕하세요 into the active text field"**:
+1. (Session already open.)
+2. `keyboard_type_unicode(text="안녕하세요")` — never `keyboard_type`; it would silently drop the characters.
+
+**"Find what currently has focus"**:
+1. `find_ui_elements(query="", states=["focused"])` — empty query is allowed when filtering by state.

--- a/integrations/opencode/plugin/src/index.ts
+++ b/integrations/opencode/plugin/src/index.ts
@@ -1,0 +1,42 @@
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Plugin } from "@opencode-ai/plugin";
+
+const PLUGIN_DIR = dirname(fileURLToPath(import.meta.url));
+const SKILL_NAME = "kwin-desktop-automation";
+const MCP_NAME = "kwin-mcp";
+
+const MCP_CONFIG = {
+  type: "local" as const,
+  command: ["uvx", "kwin-mcp"],
+  enabled: true,
+};
+
+function findSkillsDir(): string | null {
+  const dir = join(PLUGIN_DIR, "..", "skill");
+  return existsSync(join(dir, SKILL_NAME, "SKILL.md")) ? dir : null;
+}
+
+const plugin: Plugin = async () => ({
+  config: async (input) => {
+    input.mcp ??= {};
+    const mcp = input.mcp as Record<string, unknown>;
+    if (!Object.prototype.hasOwnProperty.call(mcp, MCP_NAME)) {
+      mcp[MCP_NAME] = MCP_CONFIG;
+    }
+    const skillsDir = findSkillsDir();
+    if (skillsDir) {
+      const cfg = input as typeof input & {
+        skills?: { paths?: string[]; urls?: string[] };
+      };
+      cfg.skills ??= {};
+      cfg.skills.paths ??= [];
+      if (!cfg.skills.paths.includes(skillsDir)) {
+        cfg.skills.paths.push(skillsDir);
+      }
+    }
+  },
+});
+
+export default plugin;

--- a/integrations/opencode/plugin/tsconfig.json
+++ b/integrations/opencode/plugin/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "rootDir": "src",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2024",
+    "lib": ["ES2024"],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/scripts/sync_plugin_version.py
+++ b/scripts/sync_plugin_version.py
@@ -1,0 +1,94 @@
+"""Sync the kwin-mcp version across plugin manifests.
+
+pyproject.toml [project].version is the source of truth. Run without args to
+update marketplace.json / plugin.json / package.json. Run with --check to fail
+when any manifest is out of sync (used by CI).
+"""
+
+import argparse
+import json
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+REPO = Path(__file__).resolve().parent.parent
+PYPROJECT = REPO / "pyproject.toml"
+
+FieldPath = tuple[str | int, ...]
+
+TARGETS: list[tuple[Path, list[FieldPath]]] = [
+    (
+        REPO / ".claude-plugin" / "marketplace.json",
+        [("metadata", "version"), ("plugins", 0, "version")],
+    ),
+    (
+        REPO / "integrations" / "claude-code" / ".claude-plugin" / "plugin.json",
+        [("version",)],
+    ),
+    (
+        REPO / "integrations" / "opencode" / "plugin" / "package.json",
+        [("version",)],
+    ),
+]
+
+
+def _load_version() -> str:
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    return data["project"]["version"]
+
+
+def _get_in(obj: Any, path: FieldPath) -> Any:
+    for key in path:
+        obj = obj[key]
+    return obj
+
+
+def _set_in(obj: Any, path: FieldPath, value: Any) -> None:
+    for key in path[:-1]:
+        obj = obj[key]
+    obj[path[-1]] = value
+
+
+def _sync(*, check: bool) -> int:
+    version = _load_version()
+    drift: list[str] = []
+
+    for path, fields in TARGETS:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        changed = False
+        for field in fields:
+            current = _get_in(data, field)
+            if current == version:
+                continue
+            if check:
+                rel = path.relative_to(REPO)
+                dotted = ".".join(str(k) for k in field)
+                drift.append(f"{rel}:{dotted} == {current!r} (expected {version!r})")
+            else:
+                _set_in(data, field, version)
+                changed = True
+        if changed:
+            path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+            print(f"updated {path.relative_to(REPO)} -> {version}")
+
+    if drift:
+        for line in drift:
+            print(line, file=sys.stderr)
+        return 1
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if any manifest is out of sync (no writes).",
+    )
+    args = parser.parse_args()
+    return _sync(check=args.check)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Add bundled plugin packages for the two MCP hosts so Claude-Code-only / OpenCode-only / both-tools users can install kwin-mcp + the desktop-automation skill in one step.

## What's added

- **Claude Code plugin** at `integrations/claude-code/` with `.claude-plugin/plugin.json`, `.mcp.json` (`uvx kwin-mcp`), and a single host-agnostic SKILL.md teaching session-mode selection, the observe→act→verify loop, and platform pitfalls.
- **Marketplace catalog** at root `.claude-plugin/marketplace.json` (single-plugin, monorepo pattern). Install via `/plugin marketplace add isac322/kwin-mcp` then `/plugin install kwin-mcp@kwin-mcp`.
- **OpenCode plugin** at `integrations/opencode/plugin/` published as `@isac322/kwin-mcp-opencode` (npm). Uses the canonical `Plugin` function contract from `@opencode-ai/plugin` v1.14+; the `config` hook injects `mcp.kwin-mcp` and adds the bundled skill directory to `skills.paths` (idempotent, `npm uninstall` cleanly removes both).
- **Build pipeline**: swc transpile (`src/` → `dist/index.js`) + `tsgo` typecheck (TypeScript v7 native preview, no .d.ts emit). `npm run build`'s `build:skill` step copies the source SKILL.md into the package — single source of truth.
- **Manual fallback** at `integrations/opencode/opencode.json.example`.
- **`scripts/sync_plugin_version.py`**: propagates `pyproject.toml [project].version` to all three plugin manifests. Idempotent; `--check` for CI verification.
- **`docs/ai-agent-integration.md`**: 3-scenario onboarding guide (Claude Code only / OpenCode only / both) + customising + troubleshooting.
- **`README.md`**: new "Recommended: install as a plugin" subsection.
- **CI**: `.github/workflows/integration.yml` cross-distro integration tests (Arch, Fedora, openSUSE Tumbleweed, Ubuntu 24.04).
- **Tests**: integration test suite under `tests/`.
- **Misc**: `src/kwin_mcp/session.py` redirects subprocess stdin to `/dev/null` so the wrapper chain does not consume MCP server stdin when kwin-mcp runs under an MCP stdio client.

## How it works

| Host | Tool name format | Install |
|---|---|---|
| Claude Code | `mcp__kwin-mcp__<bare>` | `/plugin marketplace add isac322/kwin-mcp` + `/plugin install kwin-mcp@kwin-mcp` |
| OpenCode | `kwin-mcp_<bare>` | `"plugin": ["@isac322/kwin-mcp-opencode"]` in `opencode.json` |

The skill body uses bare tool names (`session_start`, `screenshot`, ...). Each host adds its own prefix automatically — no SKILL fork needed for new hosts.

## Validation

- `npm run build` + `npm run typecheck` pass on the OpenCode plugin
- `python3 scripts/sync_plugin_version.py --check` passes
- Plugin verified loaded in OpenCode 1.14.31 (30 tools registered, skill auto-injected via `skills.paths`)
- See `docs/ai-agent-integration.md` for full onboarding flows
