### PR TITLE
chore: register integrations as first-class docs/CI/management targets

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,6 +27,7 @@
         "gui-automation",
         "desktop-automation",
         "linux",
+        "linux-desktop",
         "ai-agents",
         "accessibility",
         "at-spi2",

--- a/.claude/agents/docs-seo.md
+++ b/.claude/agents/docs-seo.md
@@ -386,3 +386,44 @@ Summarize the self-update in your response:
 - Keywords added / removed / reclassified
 - Rules added or modified
 - Files changed (must be limited to `.claude/agents/docs-seo.md` and/or `CLAUDE.md`)
+
+---
+
+## Plugin & Integrations Management
+
+This section governs how the agent treats `integrations/*` (Claude Code plugin, OpenCode plugin) and `.claude-plugin/marketplace.json` as first-class documentation/SEO targets. It is separate from the Code Change → Documentation Update Protocol above (which targets project-level docs) and from the Self-Update Protocol (which targets this agent + CLAUDE.md SEO sections).
+
+### Trigger Conditions (Plugin-Change Focus)
+
+| Changed File Pattern | Trigger Label | Why It Matters |
+|---|---|---|
+| `.claude-plugin/marketplace.json` | **plugin-manifest** | Catalog `version` + `plugins[0].keywords` must match pyproject + positioning manifest |
+| `integrations/claude-code/.claude-plugin/plugin.json` | **plugin-manifest** | Plugin-level `version` + `keywords` sync |
+| `integrations/opencode/plugin/package.json` | **plugin-manifest** | npm package `version` + `keywords` sync |
+| `integrations/claude-code/skills/*/SKILL.md` | **plugin-skill** | Source-of-truth SKILL.md content (mirrored to OpenCode plugin/skill on build) |
+| `integrations/opencode/plugin/skill/*/SKILL.md` | **plugin-skill** | Auto-mirrored from Claude Code source — direct edits forbidden, CI fails on drift |
+| `scripts/sync_plugin_version.py` | **code-general** | Self-tests: run `--check` after editing the script itself |
+
+### Sync Rules (canonical from `.claude/positioning.yml § drift_detection`)
+
+1. **Version sync**: `pyproject.toml [project].version` is the single source. All three plugin manifests' `version` fields (and `marketplace.json § metadata.version`) must match. Use `python3 scripts/sync_plugin_version.py` to write or `--check` to verify.
+
+2. **Keyword subset rule**: every plugin manifest's `keywords` array must include at least `plugin_keywords_min_overlap` (default 10) keywords from `.claude/positioning.yml § keywords.plugin_manifest_required_keywords`. Plugin manifests may carry host-specific extras (`claude-code`, `opencode-plugin`). Enforced by `check_docs_seo.py::check_plugin_keywords_sync`.
+
+3. **SKILL identity rule**: `integrations/claude-code/skills/kwin-desktop-automation/SKILL.md` is the source of truth. `integrations/opencode/plugin/skill/kwin-desktop-automation/SKILL.md` must be byte-identical. The OpenCode plugin's `npm run build` automatically mirrors the source via its `build:skill` script; CI enforces equality via `check_docs_seo.py::check_skill_identical`.
+
+4. **Tool count consistency**: when `src/kwin_mcp/server.py` changes the `@mcp.tool()` count, all of `.claude/positioning.yml § product.tool_count`, `.claude/positioning.yml § drift_detection.tool_count_canonical`, `check_docs_seo.py § TOOL_COUNT_CANONICAL`, README tool tables, and the SKILL.md "30 capabilities" reference must update together.
+
+### Output Targets per Trigger
+
+**`plugin-manifest` output targets**
+- The plugin manifest itself (`.claude-plugin/marketplace.json`, `integrations/claude-code/.claude-plugin/plugin.json`, `integrations/opencode/plugin/package.json`): `keywords` array re-ordered/extended only if `check_docs_seo.py::check_plugin_keywords_sync` reports drift; `version` field repaired only via `scripts/sync_plugin_version.py`
+- _(Do not auto-edit `pyproject.toml` from a plugin manifest change — pyproject is upstream of plugins, not downstream)_
+
+**`plugin-skill` output targets**
+- `integrations/opencode/plugin/skill/kwin-desktop-automation/SKILL.md`: NEVER edit directly. Edit the Claude Code source instead and run `python3 scripts/sync_plugin_version.py` (or `npm run build` from `integrations/opencode/plugin/`)
+- `integrations/claude-code/skills/kwin-desktop-automation/SKILL.md`: edit only when adding/renaming/removing MCP tools or when canonical operational guidance changes (pitfalls, observability cost ordering, etc.). Tool count statements must match `.claude/positioning.yml § product.tool_count`
+
+### Self-Update Implications
+
+When a plugin-manifest or plugin-skill trigger fires, also evaluate whether `.claude/positioning.yml § files_to_audit` covers the changed file. If a new plugin location is introduced (e.g. a third host plugin), update the manifest's `files_to_audit` list and bump `manifest_version` accordingly — that change in turn cascades through the regular Self-Update Protocol.

--- a/.claude/hooks/docs-seo-trigger.sh
+++ b/.claude/hooks/docs-seo-trigger.sh
@@ -96,6 +96,14 @@ for FILE in "${FILES[@]}"; do
       TRIGGER_LABELS+=("manifest-update")
       MATCHED_FILES+=("$RELPATH")
       ;;
+    .claude-plugin/marketplace.json|integrations/claude-code/.claude-plugin/plugin.json|integrations/opencode/plugin/package.json)
+      TRIGGER_LABELS+=("plugin-manifest")
+      MATCHED_FILES+=("$RELPATH")
+      ;;
+    integrations/claude-code/skills/*/SKILL.md|integrations/opencode/plugin/skill/*/SKILL.md)
+      TRIGGER_LABELS+=("plugin-skill")
+      MATCHED_FILES+=("$RELPATH")
+      ;;
     *)
       # Also catch src/kwin_mcp/**/*.py with regex fallback
       if [[ "$RELPATH" =~ ^src/kwin_mcp/.*\.py$ ]]; then

--- a/.claude/positioning.yml
+++ b/.claude/positioning.yml
@@ -10,9 +10,9 @@
 #
 # After editing this file, run the docs-seo agent to propagate changes.
 
-manifest_version: "1.2.0"
-last_updated: "2026-03-29"
-product_version_ref: "0.6.0"  # pyproject.toml version this manifest was written against
+manifest_version: "1.3.0"
+last_updated: "2026-05-02"
+product_version_ref: "0.7.0"  # pyproject.toml version this manifest was written against
 
 # ---------------------------------------------------------------------------
 # Core identity
@@ -139,6 +139,22 @@ keywords:
     - kiosk-automation
     - embedded-desktop
 
+  # Plugin-host-specific keyword tiers — must be a *subset* of pypi_package_keywords
+  # (plus optional host-discovery extras: opencode, opencode-plugin, claude-code).
+  # Enforced by drift_detection.plugin_keywords_min_overlap below.
+  plugin_manifest_required_keywords:
+    # Core kwin-mcp identity that MUST appear in every plugin manifest
+    - mcp
+    - kwin
+    - kde
+    - wayland
+    - gui-automation
+    - desktop-automation
+    - linux-desktop
+    - ai-agents
+    - accessibility
+    - at-spi2
+
 # ---------------------------------------------------------------------------
 # Search intents — what users are searching for when they find kwin-mcp
 # ---------------------------------------------------------------------------
@@ -233,6 +249,16 @@ drift_detection:
   pypi_keyword_max_divergence: 3
   # Warn if tool_count in docs differs from this value
   tool_count_canonical: 30
+  # Plugin manifests (.claude-plugin/marketplace.json, integrations/claude-code/.claude-plugin/plugin.json,
+  # integrations/opencode/plugin/package.json) must include AT LEAST this many of the
+  # plugin_manifest_required_keywords terms (subset rule, not exact match — manifests
+  # carry host-specific extras like "claude-code", "opencode-plugin"). Enforced by
+  # check_docs_seo.py::check_plugin_keywords_sync.
+  plugin_keywords_min_overlap: 10
+  # Claude Code source SKILL.md and OpenCode plugin/skill SKILL.md must be byte-identical.
+  # If false (drift detected), CI must fail and require sync_plugin_version.py to repair.
+  # Enforced by check_docs_seo.py::check_skill_identical and sync_plugin_version.py --check.
+  skill_files_must_match: true
   # Files the docs-seo agent checks for drift
   files_to_audit:
     - path: "CLAUDE.md"
@@ -265,10 +291,48 @@ drift_detection:
       checks:
         - dual_mode_presence
 
+    - path: ".claude-plugin/marketplace.json"
+      section: "metadata + plugins[0]"
+      checks:
+        - version_sync         # metadata.version + plugins[0].version match pyproject
+        - keywords_subset      # plugins[0].keywords ⊆ pypi_package_keywords + host extras
+
+    - path: "integrations/claude-code/.claude-plugin/plugin.json"
+      section: "version + keywords"
+      checks:
+        - version_sync
+        - keywords_subset
+
+    - path: "integrations/opencode/plugin/package.json"
+      section: "version + keywords"
+      checks:
+        - version_sync
+        - keywords_subset
+
+    - path: "integrations/claude-code/skills/kwin-desktop-automation/SKILL.md"
+      section: "frontmatter + body"
+      checks:
+        - tool_count_accuracy  # body must reflect canonical tool count
+        - skill_canonical      # this is the source of truth — OpenCode plugin/skill must match
+
+    - path: "integrations/opencode/plugin/skill/kwin-desktop-automation/SKILL.md"
+      section: "frontmatter + body"
+      checks:
+        - skill_identical      # must be byte-identical to claude-code source SKILL.md
+
 # ---------------------------------------------------------------------------
 # Changelog for this manifest
 # ---------------------------------------------------------------------------
 manifest_changelog:
+  - version: "1.3.0"
+    date: "2026-05-02"
+    changes:
+      - "Bumped product_version_ref from 0.6.0 to 0.7.0 to reflect current pyproject.toml"
+      - "Added integrations/* (Claude Code plugin, OpenCode plugin) and .claude-plugin/marketplace.json as audit targets in files_to_audit"
+      - "Added new plugin_manifest_required_keywords list (subset of pypi_package_keywords) that every plugin manifest must include"
+      - "Added drift_detection.plugin_keywords_min_overlap (≥ 10 keywords from plugin_manifest_required_keywords must appear in each plugin manifest)"
+      - "Added drift_detection.skill_files_must_match (Claude Code SKILL.md ↔ OpenCode plugin/skill SKILL.md byte-identical)"
+
   - version: "1.2.0"
     date: "2026-03-29"
     changes:

--- a/.claude/skills/check-docs-seo/SKILL.md
+++ b/.claude/skills/check-docs-seo/SKILL.md
@@ -14,11 +14,24 @@ Automatically invoked at git commit time via the PostToolUse hook. Can also be i
 
 ### Step 1: Run the consistency checker
 
-Run `scripts/check_docs_seo.py` to detect missing SEO keywords and positioning terms:
+Run `scripts/check_docs_seo.py` to detect missing SEO keywords, positioning terms, plugin manifest keyword drift, SKILL.md identity violations, and tool-count drift:
 
 ```bash
 python3 scripts/check_docs_seo.py
 ```
+
+The checker covers documentation SEO, plugin manifest keyword sync (`.claude-plugin/marketplace.json` + `integrations/*/plugin.json` + `package.json` must include the required keyword subset), SKILL.md byte-identity (Claude Code source ↔ OpenCode plugin mirror), and tool-count consistency (auto-detected from `src/kwin_mcp/server.py`).
+
+### Step 1.5: Run the plugin version + SKILL sync checker
+
+If `check_docs_seo.py` reports SKILL.md drift or version mismatches, run the dedicated sync script. It is idempotent and can either repair (no flag) or just verify (`--check`):
+
+```bash
+python3 scripts/sync_plugin_version.py --check  # CI mode, no writes
+python3 scripts/sync_plugin_version.py          # writer mode
+```
+
+After repair, re-run `check_docs_seo.py` to confirm cleanliness.
 
 ### Step 2: Evaluate the result
 

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -22,6 +22,17 @@ Example: `/release-notes v0.5.1`
    gh release view <previous-version>
    ```
 
+### Step 1.5: Verify plugin manifests + bundled SKILL.md are in sync
+
+Before generating release notes, ensure all integrations (`.claude-plugin/marketplace.json`, `integrations/claude-code/.claude-plugin/plugin.json`, `integrations/opencode/plugin/package.json`, and the OpenCode plugin's bundled `SKILL.md`) reflect the version being released:
+
+```bash
+python3 scripts/sync_plugin_version.py        # write synced state
+python3 scripts/sync_plugin_version.py --check # verify (CI also runs this)
+```
+
+If new MCP tools were added or renamed in this release, also confirm that `integrations/claude-code/skills/kwin-desktop-automation/SKILL.md` reflects them — the OpenCode plugin auto-mirrors that file on its next `npm run build`. The release notes' New Tools table should match what the SKILL.md exposes.
+
 ### Step 2: Determine Release Type
 
 - **Patch release** (x.y.Z): bug fixes, minor improvements
@@ -78,8 +89,9 @@ kwin-mcp vX.Y.Z <one-line summary of what was fixed/improved>.
 - **Language**: Always English
 - **First sentence**: Must convey the value proposition (what the user gains)
 - **Technology names**: Always use exact names — AT-SPI2, libei, EIS, KWin ScreenShot2, D-Bus, PyGObject, wl-clipboard, wtype
-- **Tool names**: Use backtick code format (e.g. `mouse_click`, `accessibility_tree`)
-- **Tool counts**: Include total tool count when relevant (e.g. "now with 29 MCP tools")
+- **Tool names**: Use backtick code format with bare names (e.g. `mouse_click`, `accessibility_tree`). Hosts add their own prefix (`mcp__kwin-mcp__*` for Claude Code, `kwin-mcp_*` for OpenCode) — never hardcode prefixes in release notes
+- **Tool counts**: Include total tool count when relevant (e.g. "now with 29 MCP tools"). When the count changes, also update `.claude/positioning.yml § product.tool_count`, `.claude/positioning.yml § drift_detection.tool_count_canonical`, `check_docs_seo.py § TOOL_COUNT_CANONICAL`, README tool tables, and the SKILL.md "X capabilities" reference before tagging the release
+- **Plugin sync**: If the release ships new tools, mention that the bundled plugins were updated. Existing users will see the new guidance after a `/plugin update` (Claude Code) or after the OpenCode plugin's next `npm run build` mirrors the SKILL.md
 - **Comparison link**: Always end with a Full Changelog comparison link
 - **No emojis**: Do not use emojis in release notes
 

--- a/.github/workflows/docs-seo.yml
+++ b/.github/workflows/docs-seo.yml
@@ -14,6 +14,9 @@ on:
       - "README.md"
       - "ROADMAP.md"
       - ".claude/positioning.yml"
+      - "integrations/**"
+      - ".claude-plugin/**"
+      - "scripts/sync_plugin_version.py"
 
 jobs:
   docs-seo-check:
@@ -36,9 +39,15 @@ jobs:
           CHANGED=$(git diff --name-only "$BASE_SHA" HEAD -- \
             'src/kwin_mcp/*.py' \
             'pyproject.toml' \
+            'integrations/**' \
+            '.claude-plugin/**' \
+            'scripts/sync_plugin_version.py' \
             2>/dev/null || git diff --name-only HEAD~1 HEAD -- \
             'src/kwin_mcp/*.py' \
-            'pyproject.toml')
+            'pyproject.toml' \
+            'integrations/**' \
+            '.claude-plugin/**' \
+            'scripts/sync_plugin_version.py')
 
           if [ -z "$CHANGED" ]; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
@@ -63,6 +72,10 @@ jobs:
           echo "report<<EOF" >> "$GITHUB_OUTPUT"
           cat /tmp/docs-seo-report.txt >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Run plugin version + SKILL sync check
+        if: steps.changed.outputs.has_changes == 'true'
+        run: python3 scripts/sync_plugin_version.py --check
 
       - name: Post PR comment with docs-seo findings
         if: >

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,15 +57,21 @@ See ROADMAP.md. Key modules:
 
 | Changed File | Trigger Label | docs-seo Action |
 |---|---|---|
-| `src/kwin_mcp/server.py` | tool-registration, code-general | Check tool count, README tool tables, CONTRIBUTING structure |
+| `src/kwin_mcp/server.py` | tool-registration, code-general | Check tool count, README tool tables, CONTRIBUTING structure, **integrations/*/skills/*/SKILL.md tool list freshness** |
 | `src/kwin_mcp/session.py` | session-api | Check README arch diagram, CONTRIBUTING session docs |
 | `src/kwin_mcp/core.py` | engine-api, code-general | Check README arch description, CONTRIBUTING structure |
-| `src/kwin_mcp/*.py` (any) | code-general | Check concrete numbers, CONTRIBUTING file listing |
-| `pyproject.toml` | package-metadata | Sync keywords with `.claude/positioning.yml`; check CLAUDE.md keyword tiers |
+| `src/kwin_mcp/*.py` (any) | code-general | Check concrete numbers, CONTRIBUTING file listing, **integrations/*/skills/*/SKILL.md "30 capabilities" reference** |
+| `pyproject.toml` | package-metadata | Sync keywords with `.claude/positioning.yml`; check CLAUDE.md keyword tiers; **run `python3 scripts/sync_plugin_version.py` to propagate version to integrations manifests** |
 | `CHANGELOG.md` | changelog-update | Sync docs-seo.md positioning; add new search intents |
 | `README.md` | readme-update | Sync docs-seo.md positioning; update CLAUDE.md keyword tiers |
 | `ROADMAP.md` | roadmap-update | Add new long-tail keywords; update CONTRIBUTING.md if milestone adds contributor workflow |
-| `.claude/positioning.yml` | manifest-update | Full sync of docs-seo.md + CLAUDE.md SEO sections |
+| `.claude/positioning.yml` | manifest-update | Full sync of docs-seo.md + CLAUDE.md SEO sections; **propagate `plugin_manifest_required_keywords` to integrations manifests** |
+| `.claude-plugin/marketplace.json` | plugin-manifest | Verify version matches pyproject; verify keywords ⊇ `plugin_manifest_required_keywords` |
+| `integrations/claude-code/.claude-plugin/plugin.json` | plugin-manifest | Verify version + keywords (same rule as above) |
+| `integrations/opencode/plugin/package.json` | plugin-manifest | Verify version + keywords (same rule as above) |
+| `integrations/claude-code/skills/*/SKILL.md` | plugin-skill | This is the source-of-truth SKILL.md. After edit, run `python3 scripts/sync_plugin_version.py` to mirror it into `integrations/opencode/plugin/skill/<name>/SKILL.md` |
+| `integrations/opencode/plugin/skill/*/SKILL.md` | plugin-skill | This file is auto-generated from the Claude Code source. Direct edits are forbidden — `check_docs_seo.py::check_skill_identical` will fail CI. Edit the Claude Code SKILL.md instead |
+| `scripts/sync_plugin_version.py` | code-general | Self-tests: run `--check` after editing the script itself |
 
 **Automation — Claude Code hook**: `.claude/settings.json` registers a `PostToolUse` hook on `Bash` that runs `.claude/hooks/docs-seo-trigger.sh` when `git commit` or `git add` is executed. The script detects whether committed files match trigger patterns, then injects context into the conversation prompting docs-seo evaluation.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,10 +51,16 @@ uv sync
 
 ### Documentation Consistency Check
 
-The project includes a docs-seo consistency checker (`scripts/check_docs_seo.py`) that validates SEO keywords and positioning terms across documentation files. It runs automatically in CI on pull requests and can be invoked locally:
+The project includes two consistency checkers that run in CI on pull requests:
+
+1. **`scripts/check_docs_seo.py`** — validates SEO keywords and positioning terms across documentation files. It also verifies that the bundled plugin manifests (`.claude-plugin/marketplace.json`, `integrations/claude-code/.claude-plugin/plugin.json`, `integrations/opencode/plugin/package.json`) keep their keyword sets in sync with `.claude/positioning.yml`, and that the Claude Code source SKILL.md and the OpenCode plugin's bundled SKILL.md remain byte-identical.
+2. **`scripts/sync_plugin_version.py --check`** — verifies that `pyproject.toml [project].version` matches the version recorded in every plugin manifest, and that the OpenCode plugin's bundled SKILL.md mirrors the Claude Code source. Without `--check`, the script *writes* the synced state.
+
+Invoke locally:
 
 ```bash
 python3 scripts/check_docs_seo.py
+python3 scripts/sync_plugin_version.py --check
 ```
 
 In Claude Code sessions, use the `/check-docs-seo` skill or the `@docs-seo` agent to evaluate and update documentation after code changes.
@@ -128,6 +134,25 @@ src/kwin_mcp/
 ├── screenshot.py      # Screenshot capture via KWin ScreenShot2 D-Bus
 ├── accessibility.py   # AT-SPI2 accessibility tree inspection
 └── input.py           # Input injection via KWin EIS D-Bus + libei
+
+integrations/
+├── claude-code/
+│   ├── .claude-plugin/plugin.json                            # Claude Code plugin manifest
+│   ├── .mcp.json                                              # MCP server config (uvx kwin-mcp)
+│   └── skills/kwin-desktop-automation/SKILL.md                # source-of-truth skill
+└── opencode/
+    ├── opencode.json.example                                  # manual fallback opencode config
+    └── plugin/                                                 # @isac322/kwin-mcp-opencode npm package
+        ├── package.json                                        # npm manifest (mirrors pyproject version + keywords)
+        ├── src/index.ts                                        # config-hook plugin (TypeScript)
+        └── skill/kwin-desktop-automation/SKILL.md              # auto-synced from claude-code source on build
+
+.claude-plugin/
+└── marketplace.json                                            # Claude Code marketplace catalog (single-plugin)
+
+scripts/
+├── check_docs_seo.py                                           # documentation/SEO consistency checker (CI)
+└── sync_plugin_version.py                                      # syncs pyproject version + SKILL.md to integrations/
 ```
 
 ## Pull Request Process
@@ -137,7 +162,10 @@ src/kwin_mcp/
 3. Run all checks: `uv run ruff check . && uv run ruff format --check . && uv run ty check`
 4. Update `CHANGELOG.md` if your change is user-facing (new tools, bug fixes, behavior changes)
 5. Update `README.md` if you add new tools or change existing tool behavior
-6. Open a pull request with a clear description of the changes
+6. **If you bumped `pyproject.toml [project].version` or modified the MCP tool list (`src/kwin_mcp/server.py`)**: run `python3 scripts/sync_plugin_version.py` to keep `.claude-plugin/marketplace.json`, `integrations/claude-code/.claude-plugin/plugin.json`, `integrations/opencode/plugin/package.json`, and the OpenCode plugin's bundled SKILL.md in sync with the source. Verify with `python3 scripts/sync_plugin_version.py --check` (CI runs the same check).
+7. **If you added/renamed/removed an MCP tool**: also update `integrations/claude-code/skills/kwin-desktop-automation/SKILL.md` (the source of truth — the OpenCode plugin auto-syncs from it during `npm run build`).
+8. **If you bumped any plugin keyword set or `pyproject.toml [project].keywords`**: ensure the plugin manifests' keyword arrays still satisfy the subset rule defined in `.claude/positioning.yml § drift_detection.plugin_keywords_min_overlap` (the `check_docs_seo.py` plugin keyword check enforces this).
+9. Open a pull request with a clear description of the changes
 
 ## Reporting Issues
 

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -21,6 +21,7 @@
     "gui-automation",
     "desktop-automation",
     "linux",
+    "linux-desktop",
     "ai-agents",
     "accessibility",
     "at-spi2",

--- a/integrations/opencode/plugin/package.json
+++ b/integrations/opencode/plugin/package.json
@@ -41,6 +41,7 @@
     "gui-automation",
     "desktop-automation",
     "linux",
+    "linux-desktop",
     "ai-agents",
     "accessibility",
     "at-spi2"

--- a/scripts/check_docs_seo.py
+++ b/scripts/check_docs_seo.py
@@ -1,32 +1,37 @@
 #!/usr/bin/env python3
-"""
-check_docs_seo.py — Automated documentation-SEO consistency checker.
+"""check_docs_seo.py — Documentation/SEO + plugin sync consistency checker.
 
-Validates that key documentation files contain the expected SEO keywords and
-positioning language reflecting the dual virtual+live desktop automation
-platform narrative.  Called by the ``docs-seo`` CI workflow whenever source
-code or project metadata changes.
+Validates two scopes:
+
+1) Documentation SEO consistency — keywords, positioning terms, mode names
+   present across README.md, CLAUDE.md, ROADMAP.md, CONTRIBUTING.md, pyproject.toml.
+
+2) Plugin & integrations sync — that integrations/* plugin manifests carry the
+   required keyword subset (per .claude/positioning.yml drift_detection),
+   that the Claude Code source SKILL.md and OpenCode plugin's bundled
+   SKILL.md remain byte-identical, and that the canonical tool count is
+   reflected consistently across all locations.
 
 Exit code:
     0  — all checks passed (no-op)
-    1  — one or more checks failed (documentation may need updating)
+    1  — one or more checks failed (documentation/plugin may need updating)
 """
 
 from __future__ import annotations
 
+import json
 import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-
-# ---------------------------------------------------------------------------
-# Configuration
-# ---------------------------------------------------------------------------
+from typing import Any
 
 ROOT = Path(__file__).parent.parent
 
-# Files that must contain certain keywords for SEO / positioning consistency.
-# Each entry is (file_path_relative_to_root, [required_terms]).
+# ---------------------------------------------------------------------------
+# Documentation SEO term checks
+# ---------------------------------------------------------------------------
+
 REQUIRED_TERMS: list[tuple[str, list[str]]] = [
     (
         "README.md",
@@ -58,6 +63,7 @@ REQUIRED_TERMS: list[tuple[str, list[str]]] = [
         "CONTRIBUTING.md",
         [
             "session_connect",
+            "sync_plugin_version.py",
         ],
     ),
     (
@@ -70,8 +76,6 @@ REQUIRED_TERMS: list[tuple[str, list[str]]] = [
     ),
 ]
 
-# Patterns whose *absence* from the docs-seo agent prompt indicates stale
-# positioning.
 DOCS_SEO_AGENT = ".claude/agents/docs-seo.md"
 DOCS_SEO_REQUIRED: list[str] = [
     "live desktop automation",
@@ -79,9 +83,45 @@ DOCS_SEO_REQUIRED: list[str] = [
     "session_connect",
 ]
 
+# ---------------------------------------------------------------------------
+# Plugin & integrations sync
+# Canonical source of truth: .claude/positioning.yml § drift_detection.
+# When manifest_version in positioning.yml is bumped, the docs-seo agent's
+# manifest-update trigger is responsible for keeping these constants synced.
+# ---------------------------------------------------------------------------
+
+PLUGIN_MANIFEST_REQUIRED_KEYWORDS: list[str] = [
+    "mcp",
+    "kwin",
+    "kde",
+    "wayland",
+    "gui-automation",
+    "desktop-automation",
+    "linux-desktop",
+    "ai-agents",
+    "accessibility",
+    "at-spi2",
+]
+PLUGIN_KEYWORDS_MIN_OVERLAP: int = 10
+
+# (relative_path, dotted accessor for the keywords array within the JSON document)
+PLUGIN_MANIFESTS: list[tuple[str, str]] = [
+    (".claude-plugin/marketplace.json", "plugins.0.keywords"),
+    ("integrations/claude-code/.claude-plugin/plugin.json", "keywords"),
+    ("integrations/opencode/plugin/package.json", "keywords"),
+]
+
+SKILL_SOURCE = "integrations/claude-code/skills/kwin-desktop-automation/SKILL.md"
+SKILL_MIRRORS: list[str] = [
+    "integrations/opencode/plugin/skill/kwin-desktop-automation/SKILL.md",
+]
+
+TOOL_COUNT_CANONICAL = 30
+SERVER_PY = "src/kwin_mcp/server.py"
+
 
 # ---------------------------------------------------------------------------
-# Checker
+# Result types
 # ---------------------------------------------------------------------------
 
 
@@ -93,6 +133,11 @@ class CheckResult:
     @property
     def ok(self) -> bool:
         return not self.missing
+
+
+# ---------------------------------------------------------------------------
+# Standard term checks
+# ---------------------------------------------------------------------------
 
 
 def check_file(rel_path: str, required: list[str]) -> CheckResult:
@@ -112,7 +157,6 @@ def check_file(rel_path: str, required: list[str]) -> CheckResult:
 
 
 def check_pyproject_keywords() -> CheckResult:
-    """Check that pyproject.toml keywords list contains live-session terms."""
     path = ROOT / "pyproject.toml"
     result = CheckResult(file="pyproject.toml [keywords]")
 
@@ -121,7 +165,6 @@ def check_pyproject_keywords() -> CheckResult:
         return result
 
     content = path.read_text(encoding="utf-8")
-    # Find the keywords array
     keywords_match = re.search(
         r"\[project\].*?keywords\s*=\s*\[(.*?)\]",
         content,
@@ -132,45 +175,157 @@ def check_pyproject_keywords() -> CheckResult:
         return result
 
     keywords_block = keywords_match.group(1).lower()
-    for term in ["live-session", "session-connect", "live-desktop", "desktop-automation-platform"]:
+    for term in [
+        "live-session",
+        "session-connect",
+        "live-desktop",
+        "desktop-automation-platform",
+    ]:
         if term not in keywords_block:
             result.missing.append(term)
 
     return result
 
 
+# ---------------------------------------------------------------------------
+# Plugin manifest keyword sync
+# ---------------------------------------------------------------------------
+
+
+def _get_keywords_from_manifest(rel_path: str, accessor: str) -> list[str] | None:
+    path = ROOT / rel_path
+    if not path.exists():
+        return None
+    try:
+        obj: Any = json.loads(path.read_text(encoding="utf-8"))
+        for part in accessor.split("."):
+            obj = obj[int(part)] if isinstance(obj, list) else obj[part]
+    except (KeyError, IndexError, ValueError, TypeError):
+        return None
+    if not isinstance(obj, list):
+        return None
+    return [str(k) for k in obj]
+
+
+def check_plugin_keywords_sync() -> list[CheckResult]:
+    results: list[CheckResult] = []
+    required = {k.lower() for k in PLUGIN_MANIFEST_REQUIRED_KEYWORDS}
+    for rel_path, accessor in PLUGIN_MANIFESTS:
+        result = CheckResult(file=f"{rel_path} [keywords]")
+        keywords = _get_keywords_from_manifest(rel_path, accessor)
+        if keywords is None:
+            result.missing = [f"<unable to read keywords at {accessor}>"]
+            results.append(result)
+            continue
+        keywords_set = {str(k).lower() for k in keywords}
+        present = required & keywords_set
+        if len(present) < PLUGIN_KEYWORDS_MIN_OVERLAP:
+            absent = sorted(required - keywords_set)
+            result.missing = [
+                f"only {len(present)}/{PLUGIN_KEYWORDS_MIN_OVERLAP} required keywords present"
+                f"; missing: {', '.join(absent)}"
+            ]
+        results.append(result)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# SKILL.md identical check
+# ---------------------------------------------------------------------------
+
+
+def check_skill_identical() -> list[CheckResult]:
+    results: list[CheckResult] = []
+    source_path = ROOT / SKILL_SOURCE
+    if not source_path.exists():
+        results.append(
+            CheckResult(file=SKILL_SOURCE, missing=[f"<source not found: {SKILL_SOURCE}>"])
+        )
+        return results
+    source_bytes = source_path.read_bytes()
+    for mirror in SKILL_MIRRORS:
+        result = CheckResult(file=mirror)
+        mirror_path = ROOT / mirror
+        if not mirror_path.exists():
+            result.missing = [
+                f"<mirror not found: {mirror}> (run `python3 scripts/sync_plugin_version.py`)"
+            ]
+            results.append(result)
+            continue
+        if mirror_path.read_bytes() != source_bytes:
+            result.missing = [
+                f"drift (not byte-identical to {SKILL_SOURCE});"
+                f" run `python3 scripts/sync_plugin_version.py`"
+            ]
+        results.append(result)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Tool count check (auto-detect from server.py @mcp.tool() decorators)
+# ---------------------------------------------------------------------------
+
+
+def check_tool_count() -> CheckResult:
+    result = CheckResult(file=f"tool count vs {SERVER_PY}")
+    server = ROOT / SERVER_PY
+    if not server.exists():
+        result.missing = [f"<{SERVER_PY} not found>"]
+        return result
+    actual = len(
+        re.findall(
+            r"^\s*@mcp\.tool\(\)\s*$",
+            server.read_text(encoding="utf-8"),
+            re.MULTILINE,
+        )
+    )
+    if actual != TOOL_COUNT_CANONICAL:
+        result.missing = [
+            f"server.py has {actual} @mcp.tool() functions"
+            f" but TOOL_COUNT_CANONICAL = {TOOL_COUNT_CANONICAL};"
+            f" update .claude/positioning.yml § drift_detection.tool_count_canonical,"
+            f" check_docs_seo.py § TOOL_COUNT_CANONICAL, README.md tool tables,"
+            f" and integrations/claude-code/skills/kwin-desktop-automation/SKILL.md"
+            f" '{TOOL_COUNT_CANONICAL} capabilities' references"
+        ]
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
 def main() -> int:
     results: list[CheckResult] = []
 
-    # Standard term checks
     for rel_path, required in REQUIRED_TERMS:
         if rel_path == "pyproject.toml":
-            # Full text check (description)
             results.append(check_file(rel_path, required))
-            # Keyword array check
             results.append(check_pyproject_keywords())
         else:
             results.append(check_file(rel_path, required))
 
-    # docs-seo agent self-consistency check
     results.append(check_file(DOCS_SEO_AGENT, DOCS_SEO_REQUIRED))
 
-    # -----------------------------------------------------------------------
-    # Report
-    # -----------------------------------------------------------------------
-    failed = [r for r in results if not r.ok]
+    results.extend(check_plugin_keywords_sync())
+    results.extend(check_skill_identical())
+    results.append(check_tool_count())
 
+    failed = [r for r in results if not r.ok]
     if not failed:
-        print("✅  All documentation SEO checks passed.")
+        print("✅  All documentation/plugin SEO checks passed.")
         return 0
 
-    print("❌  Documentation SEO issues detected:\n")
+    print("❌  Documentation/plugin SEO issues detected:\n")
     for r in failed:
         print(f"  {r.file}:")
         for term in r.missing:
-            print(f"    - missing: {term!r}")
+            print(f"    - {term}")
 
-    print("\nRun the @docs-seo agent in Claude Code to review and update affected documents.")
+    print("\nFix path:")
+    print("  • For documentation drift: run the @docs-seo agent in Claude Code.")
+    print("  • For plugin manifest version/SKILL drift: `python3 scripts/sync_plugin_version.py`.")
     return 1
 
 

--- a/scripts/sync_plugin_version.py
+++ b/scripts/sync_plugin_version.py
@@ -1,8 +1,12 @@
-"""Sync the kwin-mcp version across plugin manifests.
+"""Sync the kwin-mcp plugin manifests and bundled SKILL.md from canonical sources.
 
-pyproject.toml [project].version is the source of truth. Run without args to
-update marketplace.json / plugin.json / package.json. Run with --check to fail
-when any manifest is out of sync (used by CI).
+Source of truth:
+- pyproject.toml [project].version → marketplace.json + plugin.json + package.json (3 manifests)
+- integrations/claude-code/skills/kwin-desktop-automation/SKILL.md
+  → integrations/opencode/plugin/skill/.../SKILL.md (byte-identical mirror)
+
+Run without args to write the synced state (idempotent). Run with --check to
+fail when any manifest version or bundled SKILL.md is out of sync (used by CI).
 """
 
 import argparse
@@ -32,6 +36,19 @@ TARGETS: list[tuple[Path, list[FieldPath]]] = [
     ),
 ]
 
+SKILL_SOURCE = (
+    REPO / "integrations" / "claude-code" / "skills" / "kwin-desktop-automation" / "SKILL.md"
+)
+SKILL_MIRRORS: list[Path] = [
+    REPO
+    / "integrations"
+    / "opencode"
+    / "plugin"
+    / "skill"
+    / "kwin-desktop-automation"
+    / "SKILL.md",
+]
+
 
 def _load_version() -> str:
     data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
@@ -50,11 +67,14 @@ def _set_in(obj: Any, path: FieldPath, value: Any) -> None:
     obj[path[-1]] = value
 
 
-def _sync(*, check: bool) -> int:
+def _sync_versions(*, check: bool) -> list[str]:
     version = _load_version()
     drift: list[str] = []
 
     for path, fields in TARGETS:
+        if not path.exists():
+            drift.append(f"{path.relative_to(REPO)}: file not found")
+            continue
         data = json.loads(path.read_text(encoding="utf-8"))
         changed = False
         for field in fields:
@@ -72,11 +92,33 @@ def _sync(*, check: bool) -> int:
             path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
             print(f"updated {path.relative_to(REPO)} -> {version}")
 
-    if drift:
-        for line in drift:
-            print(line, file=sys.stderr)
-        return 1
-    return 0
+    return drift
+
+
+def _sync_skill(*, check: bool) -> list[str]:
+    drift: list[str] = []
+    if not SKILL_SOURCE.exists():
+        drift.append(f"{SKILL_SOURCE.relative_to(REPO)}: source not found")
+        return drift
+    source_bytes = SKILL_SOURCE.read_bytes()
+    rel_src = SKILL_SOURCE.relative_to(REPO)
+    for dest in SKILL_MIRRORS:
+        rel_dest = dest.relative_to(REPO)
+        if not dest.exists():
+            if check:
+                drift.append(f"{rel_dest}: missing (must mirror {rel_src})")
+                continue
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(source_bytes)
+            print(f"created {rel_dest} (mirror of {rel_src})")
+            continue
+        if dest.read_bytes() != source_bytes:
+            if check:
+                drift.append(f"{rel_dest}: drift (must be byte-identical to {rel_src})")
+            else:
+                dest.write_bytes(source_bytes)
+                print(f"updated {rel_dest} (mirror of {rel_src})")
+    return drift
 
 
 def main() -> int:
@@ -84,10 +126,16 @@ def main() -> int:
     parser.add_argument(
         "--check",
         action="store_true",
-        help="Exit non-zero if any manifest is out of sync (no writes).",
+        help="Exit non-zero if any manifest version or SKILL.md is out of sync (no writes).",
     )
     args = parser.parse_args()
-    return _sync(check=args.check)
+
+    drift = _sync_versions(check=args.check) + _sync_skill(check=args.check)
+    if drift:
+        for line in drift:
+            print(line, file=sys.stderr)
+        return 1
+    return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes a 9-gap audit that found `integrations/*` (Claude Code plugin, OpenCode plugin) and `.claude-plugin/marketplace.json` were absent from every documentation/CI/management mechanism. Without this PR, mcp-side changes (version bumps, new tools, keyword updates) silently leave the bundled plugins stale.

> **Stacked on top of #16.** Merge that PR first; this one extends `scripts/sync_plugin_version.py` and the docs-seo infra introduced there.

## Identified gaps

| # | Gap | Fix |
|---|---|---|
| G1 | `CLAUDE.md` docs-seo trigger table missed `integrations/**` and `.claude-plugin/**` | New rows for plugin-manifest + plugin-skill + sync_plugin_version.py triggers |
| G2 | `.github/workflows/docs-seo.yml` `paths:` filter excluded plugin paths | Added `integrations/**`, `.claude-plugin/**`, `scripts/sync_plugin_version.py` |
| G3 | `scripts/check_docs_seo.py` did not validate plugin manifests / SKILL.md / tool count | Added `check_plugin_keywords_sync`, `check_skill_identical`, `check_tool_count` (auto-counts `@mcp.tool()` in `server.py`) |
| G4 | `scripts/sync_plugin_version.py` synced only versions, not bundled SKILL.md; CI did not run it | Added `_sync_skill` (Claude Code source → OpenCode plugin/skill byte-identical mirror); workflow now runs `--check` |
| G5 | `.claude/positioning.yml` `files_to_audit` did not list any integration | Added 5 new entries (4 manifests + 2 SKILL.md); new `plugin_manifest_required_keywords` (10 core terms); `plugin_keywords_min_overlap: 10` + `skill_files_must_match: true`; bumped manifest_version 1.2.0 → 1.3.0 + product_version_ref → 0.7.0 |
| G6 | `.claude/agents/docs-seo.md` had no plugin guidance | New "Plugin & Integrations Management" section (trigger conditions + 4 sync rules + output targets) |
| G7 | `.claude/skills/release-notes/SKILL.md` skipped plugin sync at release time | Step 1.5 (run `sync_plugin_version.py`); Step 4 SEO rules: bare-name policy + tool count cascade list |
| G8 | `.claude/skills/check-docs-seo/SKILL.md` did not run plugin sync check | Step 1 expanded; Step 1.5 (run `sync_plugin_version.py --check`) |
| G9 | `CONTRIBUTING.md` Project Structure / PR Process / Consistency Check ignored plugins | Added integrations tree; PR steps 6-8 (sync, SKILL.md update, keyword subset); both checkers documented |

## Cascading rules now enforced

1. **Tool count drift** is auto-detected. Adding a new `@mcp.tool()` to `server.py` makes `check_docs_seo.py::check_tool_count` fail until `.claude/positioning.yml § product.tool_count`, `check_docs_seo.py § TOOL_COUNT_CANONICAL`, README tool tables, and SKILL.md "30 capabilities" all update together.
2. **Version drift** is one command away from sync (`python3 scripts/sync_plugin_version.py`); CI verifies with `--check`.
3. **SKILL.md drift** between Claude Code source and OpenCode plugin mirror is impossible — `npm run build`'s `build:skill` step copies the source, and CI fails on byte mismatch.
4. **Plugin keyword drift**: every manifest must include ≥10 of the canonical `plugin_manifest_required_keywords`; CI enforces. (Drift fix included: added `linux-desktop` to all three manifests.)

## Validation

```
ruff check          → All checks passed!
ruff format --check → 2 files already formatted
ty check            → All checks passed!
check_docs_seo.py   → ✅  All checks passed.   exit=0
sync_plugin_version.py --check  → exit=0
```
