### PR TITLE
fix(marketplace): drop pluginRoot, point source at integrations/claude-code

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,13 +8,12 @@
   },
   "metadata": {
     "description": "kwin-mcp marketplace — MCP server and skill for Linux KDE Plasma 6 Wayland desktop GUI automation (virtual sessions for headless testing, live sessions for real-desktop / container / kiosk control).",
-    "version": "0.7.0",
-    "pluginRoot": "./integrations"
+    "version": "0.7.0"
   },
   "plugins": [
     {
       "name": "kwin-mcp",
-      "source": "./claude-code",
+      "source": "./integrations/claude-code",
       "version": "0.7.0",
       "description": "Bundles the kwin-mcp MCP server (uvx kwin-mcp) plus the kwin-desktop-automation skill that teaches session-mode selection, the observe-act-verify loop, US-QWERTY vs Unicode typing, and platform pitfalls (surface-local coordinates, QMenu invisibility, EIS edge limits, clipboard opt-in).",
       "category": "automation",


### PR DESCRIPTION
## Summary

`claude plugin install --scope project kwin-mcp@kwin-mcp` failed with:

```
Source path does not exist: /home/<user>/.claude/plugins/marketplaces/kwin-mcp/claude-code
```

Root cause: the marketplace catalog used `metadata.pluginRoot: "./integrations"` + `plugins[0].source: "./claude-code"` expecting Claude Code to concatenate the two and resolve to `integrations/claude-code/`. In practice the `pluginRoot` prefix is **not** applied — `source` is resolved relative to the marketplace root.

## Evidence

- Anthropic's own canonical marketplace ([anthropics/claude-code/.claude-plugin/marketplace.json](https://github.com/anthropics/claude-code/blob/5bf19945e4e9e38d298ddc2befd5c30a7d504fb8/.claude-plugin/marketplace.json#L10-L149)) does **not** use `pluginRoot`. Every plugin's `source` is the full sub-path (`./plugins/<name>`).
- Claude Code official docs are inconsistent: one paragraph describes `pluginRoot` as a "base directory prepended to relative plugin source paths"; another says relative-path sources resolve from the marketplace root. Runtime behaviour matches the latter.
- Multiple open issues in `anthropics/claude-code` describe `pluginRoot` / `source` resolution surprises (#25835, #29485, #26357).

## Fix

```diff
   "metadata": {
     "description": "...",
-    "version": "0.7.0",
-    "pluginRoot": "./integrations"
+    "version": "0.7.0"
   },
   "plugins": [
     {
       "name": "kwin-mcp",
-      "source": "./claude-code",
+      "source": "./integrations/claude-code",
```

Pattern matches the canonical Anthropic marketplace.

## Verification

After merge + Claude Code marketplace cache refresh (`/plugin marketplace remove kwin-mcp` then `/plugin marketplace add isac322/kwin-mcp`):

```
claude plugin install --scope project kwin-mcp@kwin-mcp
```

should succeed — `<marketplace-root>/integrations/claude-code/` contains `.claude-plugin/plugin.json` and `.mcp.json`.

## Related

- Anthropic canonical pattern: https://github.com/anthropics/claude-code/blob/main/.claude-plugin/marketplace.json
- pluginRoot discussion: https://github.com/jeremylongshore/claude-code-plugins-plus-skills/discussions/100
