### PR TITLE
docs(spike): screenshot + KWin scripting feasibility reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
     tags: ["v*"]
   pull_request:
-    branches: [main]
 
 jobs:
   lint:

--- a/.github/workflows/docs-seo.yml
+++ b/.github/workflows/docs-seo.yml
@@ -6,7 +6,6 @@ name: Docs & SEO Review
 # when the detected changes do not warrant a documentation review.
 on:
   pull_request:
-    branches: [main]
     paths:
       - "src/kwin_mcp/**"
       - "pyproject.toml"

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ kwin-mcp-cli --default-live-session
 | `read_app_log` | `pid` `int`, `last_n_lines?` `int` (50) | Read stdout/stderr output of a launched app by PID. Set `last_n_lines=0` for all output. |
 | `wayland_info` | `filter_protocol?` `str` | List Wayland protocols available in the session. Useful for verifying protocol access (e.g., `plasma_window_management`). |
 
-> **Frame capture:** Many action tools accept an optional `screenshot_after_ms` parameter (e.g., `[0, 50, 100, 200, 500]`) that captures screenshots at specified delays (in milliseconds) after the action completes. This is useful for observing transient UI states like hover effects, click animations, and menu transitions without extra MCP round-trips. Frame capture uses the fast KWin ScreenShot2 D-Bus interface (~30-70ms per frame).
+> **Frame capture:** Many action tools accept an optional `screenshot_after_ms` parameter (e.g., `[0, 50, 100, 200, 500]`) that captures screenshots at specified delays (in milliseconds) after the action completes. This is useful for observing transient UI states like hover effects, click animations, and menu transitions without extra MCP round-trips. Frame capture tries the fast KWin ScreenShot2 D-Bus interface (~30-70ms per frame) and falls back to `spectacle` when ScreenShot2 is unavailable.
 
 ## How It Works
 
@@ -283,7 +283,7 @@ kwin-mcp server  (30 tools)       kwin-mcp-cli (interactive REPL)
   |-- mouse_* ------------------> KWin EIS D-Bus --> libei
   |-- keyboard_* ---------------> KWin EIS D-Bus --> libei
   |-- touch_* ------------------> KWin EIS D-Bus --> libei
-  |    +-- screenshot_after_ms -> KWin ScreenShot2 D-Bus (fast frame capture)
+  |    +-- screenshot_after_ms -> KWin ScreenShot2 D-Bus (fast path, spectacle fallback)
   |
   |-- keyboard_type_unicode ----> wtype / wl-copy + Ctrl+V
   |-- clipboard_* --------------> wl-copy / wl-paste (wl-clipboard)

--- a/docs/design/kwin-scripting-feasibility.md
+++ b/docs/design/kwin-scripting-feasibility.md
@@ -1,0 +1,117 @@
+# KWin Scripting Feasibility — KDE Plasma 6
+
+## KWin version
+
+- `kwin_wayland --version`: `kwin 6.6.4`
+- Probe command: `bash scripts/kwin_scripting_probe.sh`
+- Session: isolated `dbus-run-session` + `kwin_wayland --virtual --no-lockscreen --width 1280 --height 720`
+
+## Result-passing mechanism comparison
+
+| Mechanism | Result | Notes |
+|---|---|---|
+| `callDBus` to `org.kwin_mcp.Probe` | Selected for the spike | Structured JSON callback over the isolated session bus. The probe registers a temporary Python `dbus.service.BusName` + `dbus.service.Object`, exposes `Result(payload: str)`, stores the payload, and unblocks a `threading.Event`. The synchronous spike listener uses `dbus.mainloop.glib` + GLib `MainLoop`; this is not a production MCP pattern. |
+| `print` / compositor log scraping | Rejected | KWin and portal logs are noisy in virtual sessions, output ordering is not a reliable request/response channel, and parsing stdout/journal output would be fragile. |
+| Temporary files | Rejected for this spike | File output would require choosing and securing a writable path inside the isolated session and still needs polling. D-Bus callbacks are simpler and closer to the intended automation control plane. |
+
+## Test results
+
+The rerun reached KWin's `/Scripting` D-Bus object and introspected it. The object exposed `loadScript`, `loadDeclarativeScript`, `isScriptLoaded`, and `unloadScript`, but not `loadScriptFromText`. Therefore all required JavaScript tests failed before execution.
+
+| Test | JS Snippet | Result |
+|---|---|---|
+| Basic window enumeration | `workspace.windowList()` and `callDBus(... JSON.stringify(results))` | Failed before execution: `org.freedesktop.DBus.Error.UnknownMethod: No such method 'loadScriptFromText' in interface 'org.kde.kwin.Scripting' at object path '/Scripting' (signature 'ss')` |
+| Active window | `workspace.activeWindow` and `callDBus(... JSON.stringify(windowOrNull))` | Failed before execution with the same `loadScriptFromText` `UnknownMethod` error |
+| Close `kcalc` window | Iterate `workspace.windowList()`, match `resourceClass === "kcalc"`, call `closeWindow()` | Failed before execution with the same `loadScriptFromText` `UnknownMethod` error |
+
+The log still contains transient `fork: retry: 자원이 일시적으로 사용 불가능함` lines from the local Python wrapper, but the Python probe eventually ran, introspected the interface, and captured the concrete D-Bus failure above. This is not classified as reproduction-blocked because actual scripting-interface results were obtained.
+
+## Working JS snippets
+
+No snippet is confirmed working on KWin `6.6.4` in this virtual-session probe because the required in-memory loader, `loadScriptFromText(script, name)`, is unavailable.
+
+## Attempted JS snippets
+
+### Basic window enumeration
+
+```javascript
+// KDE Plasma 6 KWin scripting — written from scratch, inspired by KDE scripting API docs
+try {
+    var wins = workspace.windowList();
+    var results = [];
+    for (var i = 0; i < wins.length; i++) {
+        var w = wins[i];
+        results.push({
+            id: String(w.internalId),
+            title: w.caption,
+            appId: String(w.resourceClass),
+            active: w === workspace.activeWindow,
+            x: w.frameGeometry.x,
+            y: w.frameGeometry.y,
+            width: w.frameGeometry.width,
+            height: w.frameGeometry.height
+        });
+    }
+    callDBus("org.kwin_mcp.Probe", "/Probe", "org.kwin_mcp.Probe", "Result", JSON.stringify(results));
+} catch (e) {
+    callDBus("org.kwin_mcp.Probe", "/Probe", "org.kwin_mcp.Probe", "Result", JSON.stringify({error: String(e)}));
+}
+```
+
+### Active window
+
+```javascript
+// KDE Plasma 6 KWin scripting — written from scratch, inspired by KDE scripting API docs
+try {
+    var w = workspace.activeWindow;
+    if (w) {
+        callDBus("org.kwin_mcp.Probe", "/Probe", "org.kwin_mcp.Probe", "Result",
+            JSON.stringify({id: String(w.internalId), title: w.caption, appId: String(w.resourceClass)}));
+    } else {
+        callDBus("org.kwin_mcp.Probe", "/Probe", "org.kwin_mcp.Probe", "Result", JSON.stringify(null));
+    }
+} catch (e) {
+    callDBus("org.kwin_mcp.Probe", "/Probe", "org.kwin_mcp.Probe", "Result", JSON.stringify({error: String(e)}));
+}
+```
+
+### Close `kcalc`
+
+```javascript
+// KDE Plasma 6 KWin scripting — written from scratch, inspired by KDE scripting API docs
+try {
+    var wins = workspace.windowList();
+    var closed = false;
+    for (var i = 0; i < wins.length; i++) {
+        if (String(wins[i].resourceClass) === "kcalc") {
+            wins[i].closeWindow();
+            callDBus("org.kwin_mcp.Probe", "/Probe", "org.kwin_mcp.Probe", "Result", JSON.stringify("closed"));
+            closed = true;
+            break;
+        }
+    }
+    if (!closed) {
+        callDBus("org.kwin_mcp.Probe", "/Probe", "org.kwin_mcp.Probe", "Result", JSON.stringify("not_found"));
+    }
+} catch (e) {
+    callDBus("org.kwin_mcp.Probe", "/Probe", "org.kwin_mcp.Probe", "Result", JSON.stringify({error: String(e)}));
+}
+```
+
+## Decision
+
+KWin scripting blocked on KWin 6.x
+
+Specific reason: KWin `6.6.4` in an isolated virtual session exposes the `/Scripting` D-Bus object, but the interface lacks the required `loadScriptFromText(script, name)` method. Because in-memory JavaScript cannot be loaded through that API, Test 1 did not pass and `callDBus` result-passing could not be verified from an executed script.
+
+## Reproduction
+
+```bash
+bash scripts/kwin_scripting_probe.sh
+```
+
+Expected current result on the tested host: KWin starts, `kcalc` launches, `/Scripting` introspection succeeds, and all three tests report `UnknownMethod` for `loadScriptFromText`.
+
+## License note
+
+The JavaScript snippets above were written from scratch from the KDE Plasma 6 scripting API shape and carry the required attribution header. No incompatible script source was copied.

--- a/docs/design/screenshot2-virtual-feasibility.md
+++ b/docs/design/screenshot2-virtual-feasibility.md
@@ -1,0 +1,61 @@
+# ScreenShot2 Virtual Session Feasibility
+
+This spike evaluates the feasibility of using KWin ScreenShot2 pipe-based D-Bus capture as the primary screenshot path inside `kwin_wayland --virtual`.
+
+- **KWin version**: `6.6.4`
+- **Session model**: fresh `dbus-run-session` + `kwin_wayland --virtual` per probe row
+- **Geometry**: `1280x720`
+- **Required environment**:
+  - `KWIN_WAYLAND_NO_PERMISSION_CHECKS=1`
+  - `KWIN_SCREENSHOT_NO_PERMISSION_CHECKS=1`
+  - `ATSPI_DBUS_IMPLEMENTATION=dbus-daemon`
+- **Output format**: `label|method|status|width|height|stride|png_path|png_size|error`
+- **Reproduction script**: `scripts/screenshot2_probe.sh`
+
+## Phase 1: Normal virtual-session baseline
+
+This section evaluates ScreenShot2 across various software-rendering environment combinations in an empty virtual session.
+
+| Combination | Extra Env Vars | CaptureActiveScreen | CaptureWorkspace | CaptureArea(0,0,1,1) |
+|---|---|---|---|---|
+| baseline | none | OK · 1280x720 · 3653 B | OK · 1280x720 · 3653 B | OK · 1x1 · 70 B |
+| kwin_prefer_sw_qpainter | `KWIN_PREFER_SW_QPAINTER=1` | OK · 1280x720 · 3653 B | OK · 1280x720 · 3653 B | OK · 1x1 · 70 B |
+| libgl_always_software | `LIBGL_ALWAYS_SOFTWARE=1` | OK · 1280x720 · 3653 B | OK · 1280x720 · 3653 B | OK · 1x1 · 70 B |
+| mesa_swrast | `MESA_LOADER_DRIVER_OVERRIDE=swrast` | OK · 1280x720 · 3653 B | OK · 1280x720 · 3653 B | OK · 1x1 · 70 B |
+| egl_surfaceless | `EGL_PLATFORM=surfaceless` | OK · 1280x720 · 3653 B | OK · 1280x720 · 3653 B | OK · 1x1 · 70 B |
+| libgl_mesa_swrast | `LIBGL_ALWAYS_SOFTWARE=1 MESA_LOADER_DRIVER_OVERRIDE=swrast` | OK · 1280x720 · 3653 B | OK · 1280x720 · 3653 B | OK · 1x1 · 70 B |
+| libgl_egl_surfaceless | `LIBGL_ALWAYS_SOFTWARE=1 EGL_PLATFORM=surfaceless` | OK · 1280x720 · 3653 B | OK · 1280x720 · 3653 B | OK · 1x1 · 70 B |
+
+## Phase 2: App scenarios
+
+This section evaluates ScreenShot2 with active applications to verify capture under realistic workloads.
+
+| Scenario | Apps | CaptureActiveScreen | CaptureWorkspace | CaptureArea(0,0,1,1) | Sample PNG |
+|---|---|---|---|---|---|
+| phase2_empty | none | OK · 1280x720 · 3653 B | OK · 1280x720 · 3653 B | OK · 1x1 · 70 B | `/tmp/screenshot2_probe_376122/phase2_empty__CaptureWorkspace.png` |
+| phase2_kcalc | `kcalc` | OK · 1280x720 · 78262 B | OK · 1280x720 · 78262 B | OK · 1x1 · 70 B | `/tmp/screenshot2_probe_376122/phase2_kcalc__CaptureWorkspace.png` |
+| phase2_multi | `kcalc`, `Dialog-One`, `Dialog-Two` | OK · 1280x720 · 91155 B | OK · 1280x720 · 91155 B | OK · 1x1 · 70 B | `/tmp/screenshot2_probe_376122/phase2_multi__CaptureWorkspace.png` |
+
+## Phase 3: Forced compositor stress
+
+These are stress tests that force the compositor mode. They are NOT representative of normal virtual KWin sessions and MUST NOT be used as primary feasibility evidence.
+
+| Combination | Extra Env Vars | CaptureActiveScreen | CaptureWorkspace | CaptureArea(0,0,1,1) |
+|---|---|---|---|---|
+| kwin_compose_o | `KWIN_COMPOSE=O` | FAIL: org.kde.KWin.ScreenShot2.Error.Cancelled: Screenshot got cancelled | FAIL: org.kde.KWin.ScreenShot2.Error.Cancelled: Screenshot got cancelled | FAIL: org.kde.KWin.ScreenShot2.Error.Cancelled: Screenshot got cancelled |
+| kwin_compose_q | `KWIN_COMPOSE=Q` | FAIL: org.kde.KWin.ScreenShot2.Error.Cancelled: Screenshot got cancelled | FAIL: org.kde.KWin.ScreenShot2.Error.Cancelled: Screenshot got cancelled | FAIL: org.kde.KWin.ScreenShot2.Error.Cancelled: Screenshot got cancelled |
+| libgl_mesa_swrast_compose_o | `LIBGL_ALWAYS_SOFTWARE=1 MESA_LOADER_DRIVER_OVERRIDE=swrast KWIN_COMPOSE=O` | FAIL: org.kde.KWin.ScreenShot2.Error.Cancelled: Screenshot got cancelled | FAIL: org.kde.KWin.ScreenShot2.Error.Cancelled: Screenshot got cancelled | FAIL: org.kde.KWin.ScreenShot2.Error.Cancelled: Screenshot got cancelled |
+
+## Action
+
+Use ScreenShot2 as the primary fast path for normal virtual KWin sessions. Keep spectacle as a compatibility fallback. Treat `KWIN_COMPOSE=O`/`KWIN_COMPOSE=Q` ScreenShot2 cancellation as an environment-specific backend failure, not as a general virtual-session limitation.
+
+## Reproduction
+
+To reproduce these results, run the following command:
+
+```bash
+bash scripts/screenshot2_probe.sh
+```
+
+This script writes PNG artifacts to `/tmp/screenshot2_probe_$$/` and prints CSV-style rows to stdout in the documented `output_format`.

--- a/scripts/kwin_scripting_probe.sh
+++ b/scripts/kwin_scripting_probe.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+set -u
+set -o pipefail
+
+SOCKET_NAME="wayland-kwin-probe-$$"
+WIDTH=1280
+HEIGHT=720
+
+echo "KWin scripting probe"
+echo "kwin_version=$(kwin_wayland --version 2>&1 | tr '\n' ' ')"
+echo "socket=${SOCKET_NAME}"
+
+dbus-run-session bash -s -- "$SOCKET_NAME" "$WIDTH" "$HEIGHT" <<'SESSION'
+set -u
+set -o pipefail
+
+SOCKET_NAME="$1"
+WIDTH="$2"
+HEIGHT="$3"
+RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+
+export KDE_FULL_SESSION=true
+export KDE_SESSION_VERSION=6
+export XDG_SESSION_TYPE=wayland
+export XDG_CURRENT_DESKTOP=KDE
+export QT_LINUX_ACCESSIBILITY_ALWAYS_ON=1
+export QT_ACCESSIBILITY=1
+export ATSPI_DBUS_IMPLEMENTATION=dbus-daemon
+export KWIN_WAYLAND_NO_PERMISSION_CHECKS=1
+export KWIN_SCREENSHOT_NO_PERMISSION_CHECKS=1
+
+KWIN_PID=""
+ATSPI_PID=""
+KCALC_PID=""
+
+cleanup() {
+    if [ -n "${KCALC_PID}" ]; then kill "${KCALC_PID}" 2>/dev/null || true; fi
+    if [ -n "${KWIN_PID}" ]; then kill "${KWIN_PID}" 2>/dev/null || true; fi
+    if [ -n "${ATSPI_PID}" ]; then kill "${ATSPI_PID}" 2>/dev/null || true; fi
+    if [ -n "${KCALC_PID}" ]; then wait "${KCALC_PID}" 2>/dev/null || true; fi
+    if [ -n "${KWIN_PID}" ]; then wait "${KWIN_PID}" 2>/dev/null || true; fi
+    if [ -n "${ATSPI_PID}" ]; then wait "${ATSPI_PID}" 2>/dev/null || true; fi
+    rm -f "${RUNTIME_DIR}/${SOCKET_NAME}" "${RUNTIME_DIR}/${SOCKET_NAME}.lock"
+}
+trap cleanup EXIT TERM INT HUP
+
+if [ -x /usr/lib/at-spi-bus-launcher ]; then
+    /usr/lib/at-spi-bus-launcher --launch-immediately &
+    ATSPI_PID=$!
+    sleep 0.2
+fi
+
+dbus-update-activation-environment WAYLAND_DISPLAY="${SOCKET_NAME}" QT_QPA_PLATFORM=wayland >/dev/null 2>&1 || true
+
+env -u WAYLAND_DISPLAY -u QT_QPA_PLATFORM \
+    KWIN_WAYLAND_NO_PERMISSION_CHECKS=1 \
+    KWIN_SCREENSHOT_NO_PERMISSION_CHECKS=1 \
+    kwin_wayland --virtual --no-lockscreen \
+    --width "${WIDTH}" --height "${HEIGHT}" \
+    --socket "${SOCKET_NAME}" &
+KWIN_PID=$!
+
+echo "dbus_address=${DBUS_SESSION_BUS_ADDRESS}"
+echo "kwin_pid=${KWIN_PID}"
+
+deadline=$((SECONDS + 10))
+while [ ! -e "${RUNTIME_DIR}/${SOCKET_NAME}" ]; do
+    if ! kill -0 "${KWIN_PID}" 2>/dev/null; then
+        echo "FAIL: kwin_wayland exited before socket creation"
+        exit 1
+    fi
+    if [ "${SECONDS}" -ge "${deadline}" ]; then
+        echo "FAIL: timed out waiting for ${RUNTIME_DIR}/${SOCKET_NAME}"
+        exit 1
+    fi
+    sleep 0.1
+done
+sleep 0.5
+
+env \
+    DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS}" \
+    WAYLAND_DISPLAY="${SOCKET_NAME}" \
+    QT_QPA_PLATFORM=wayland \
+    KWIN_WAYLAND_NO_PERMISSION_CHECKS=1 \
+    KWIN_SCREENSHOT_NO_PERMISSION_CHECKS=1 \
+    ATSPI_DBUS_IMPLEMENTATION=dbus-daemon \
+    kcalc >/tmp/kwin-scripting-probe-kcalc-$$.log 2>&1 &
+KCALC_PID=$!
+echo "kcalc_pid=${KCALC_PID}"
+sleep 2
+
+python3 - <<'PY'
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from dataclasses import dataclass
+
+import dbus
+import dbus.bus
+import dbus.mainloop.glib
+import dbus.service
+from gi.repository import GLib
+
+
+@dataclass
+class ProbeState:
+    payload: str | None = None
+    event: threading.Event = threading.Event()
+
+
+class ProbeObject(dbus.service.Object):
+    def __init__(self, bus: dbus.bus.BusConnection, state: ProbeState) -> None:
+        self._state = state
+        super().__init__(bus, "/Probe")
+
+    @dbus.service.method("org.kwin_mcp.Probe", in_signature="s", out_signature="")
+    def Result(self, payload: str) -> None:
+        self._state.payload = str(payload)
+        self._state.event.set()
+
+
+HEADER = "// KDE Plasma 6 KWin scripting — written from scratch, inspired by KDE scripting API docs"
+
+TESTS = [
+    (
+        "basic window enumeration",
+        HEADER
+        + r'''
+try {
+    var wins = workspace.windowList();
+    var results = [];
+    for (var i = 0; i < wins.length; i++) {
+        var w = wins[i];
+        results.push({
+            id: String(w.internalId),
+            title: w.caption,
+            appId: String(w.resourceClass),
+            active: w === workspace.activeWindow,
+            x: w.frameGeometry.x,
+            y: w.frameGeometry.y,
+            width: w.frameGeometry.width,
+            height: w.frameGeometry.height
+        });
+    }
+    callDBus("org.kwin_mcp.Probe", "/Probe", "org.kwin_mcp.Probe", "Result", JSON.stringify(results));
+} catch (e) {
+    callDBus("org.kwin_mcp.Probe", "/Probe", "org.kwin_mcp.Probe", "Result", JSON.stringify({error: String(e)}));
+}
+''',
+    ),
+    (
+        "active window",
+        HEADER
+        + r'''
+try {
+    var w = workspace.activeWindow;
+    if (w) {
+        callDBus("org.kwin_mcp.Probe", "/Probe", "org.kwin_mcp.Probe", "Result",
+            JSON.stringify({id: String(w.internalId), title: w.caption, appId: String(w.resourceClass)}));
+    } else {
+        callDBus("org.kwin_mcp.Probe", "/Probe", "org.kwin_mcp.Probe", "Result", JSON.stringify(null));
+    }
+} catch (e) {
+    callDBus("org.kwin_mcp.Probe", "/Probe", "org.kwin_mcp.Probe", "Result", JSON.stringify({error: String(e)}));
+}
+''',
+    ),
+    (
+        "close kcalc by resourceClass",
+        HEADER
+        + r'''
+try {
+    var wins = workspace.windowList();
+    var closed = false;
+    for (var i = 0; i < wins.length; i++) {
+        if (String(wins[i].resourceClass) === "kcalc") {
+            wins[i].closeWindow();
+            callDBus("org.kwin_mcp.Probe", "/Probe", "org.kwin_mcp.Probe", "Result", JSON.stringify("closed"));
+            closed = true;
+            break;
+        }
+    }
+    if (!closed) {
+        callDBus("org.kwin_mcp.Probe", "/Probe", "org.kwin_mcp.Probe", "Result", JSON.stringify("not_found"));
+    }
+} catch (e) {
+    callDBus("org.kwin_mcp.Probe", "/Probe", "org.kwin_mcp.Probe", "Result", JSON.stringify({error: String(e)}));
+}
+''',
+    ),
+]
+
+
+def call_script_run(bus: dbus.bus.BusConnection, script_id: int) -> None:
+    paths = [f"/Scripting/Script{script_id}", f"/Scripting/Script/{script_id}"]
+    ifaces = ["org.kde.kwin.Script", "org.kde.KWin.Script"]
+    last_error: Exception | None = None
+    for path in paths:
+        for iface_name in ifaces:
+            try:
+                obj = bus.get_object("org.kde.KWin", path)
+                iface = dbus.Interface(obj, iface_name)
+                iface.run()
+                return
+            except Exception as exc:  # noqa: BLE001 - probe reports all D-Bus variants tried
+                last_error = exc
+    raise RuntimeError(f"could not run Script({script_id}): {last_error}")
+
+
+def main() -> int:
+    dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+    bus = dbus.bus.BusConnection(os.environ["DBUS_SESSION_BUS_ADDRESS"])
+    state = ProbeState()
+    bus_name = dbus.service.BusName("org.kwin_mcp.Probe", bus)
+    probe = ProbeObject(bus, state)
+    loop = GLib.MainLoop()
+    loop_thread = threading.Thread(target=loop.run, daemon=True)
+    loop_thread.start()
+
+    kwin_obj = bus.get_object("org.kde.KWin", "/Scripting")
+    scripting = dbus.Interface(kwin_obj, "org.kde.kwin.Scripting")
+    introspection = kwin_obj.Introspect(dbus_interface="org.freedesktop.DBus.Introspectable")
+    method_names = [line.strip() for line in str(introspection).splitlines() if "<method" in line]
+    print("scripting_methods=" + "; ".join(method_names))
+    print("probe_service=org.kwin_mcp.Probe")
+
+    failures = 0
+    try:
+        for index, (test_name, js_code) in enumerate(TESTS, start=1):
+            script_name = f"kwin_mcp_probe_{index}_{int(time.time() * 1000)}"
+            state.payload = None
+            state.event.clear()
+            try:
+                script_id = int(scripting.loadScriptFromText(js_code, script_name))
+                print(f"script_id[{test_name}]={script_id}")
+                if script_id == -1:
+                    print(f"FAIL: {test_name}: loadScriptFromText returned -1 (script rejected)")
+                    failures += 1
+                    continue
+                call_script_run(bus, script_id)
+                if not state.event.wait(8):
+                    print(f"FAIL: {test_name}: timed out waiting for callDBus Result after 8s")
+                    failures += 1
+                    continue
+                print(f"payload[{test_name}]={state.payload}")
+                try:
+                    parsed = json.loads(state.payload or "null")
+                except json.JSONDecodeError as exc:
+                    print(f"FAIL: {test_name}: payload is not JSON: {exc}")
+                    failures += 1
+                    continue
+                if isinstance(parsed, dict) and "error" in parsed:
+                    print(f"FAIL: {test_name}: JavaScript error: {parsed['error']}")
+                    failures += 1
+                    continue
+                if test_name == "basic window enumeration" and not isinstance(parsed, list):
+                    print(f"FAIL: {test_name}: expected JSON array, got {type(parsed).__name__}")
+                    failures += 1
+                    continue
+                if test_name == "close kcalc by resourceClass" and parsed != "closed":
+                    print(f"FAIL: {test_name}: expected closed, got {parsed!r}")
+                    failures += 1
+                    continue
+                print(f"PASS: {test_name}")
+            except Exception as exc:  # noqa: BLE001 - probe should continue across tests
+                print(f"FAIL: {test_name}: {type(exc).__name__}: {exc}")
+                failures += 1
+            finally:
+                try:
+                    scripting.unloadScript(script_name)
+                except Exception as exc:  # noqa: BLE001 - cleanup best effort
+                    print(f"WARN: unloadScript({script_name}) failed: {type(exc).__name__}: {exc}")
+    finally:
+        probe.remove_from_connection()
+        del bus_name
+        loop.quit()
+        loop_thread.join(timeout=2)
+
+    if failures:
+        print(f"SUMMARY: FAIL ({failures} failed)")
+        return 0
+    print("SUMMARY: PASS")
+    return 0
+
+
+raise SystemExit(main())
+PY
+SESSION

--- a/scripts/screenshot2_probe.sh
+++ b/scripts/screenshot2_probe.sh
@@ -1,0 +1,376 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WIDTH="${WIDTH:-1280}"
+HEIGHT="${HEIGHT:-720}"
+OUTPUT_DIR="${OUTPUT_DIR:-/tmp/screenshot2_probe_$$}"
+SOCKET_PREFIX="wayland-spike-$$"
+RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+
+PY_HELPER="$(mktemp /tmp/screenshot2_probe_helper.XXXXXX.py)"
+INNER_SCRIPT="$(mktemp /tmp/screenshot2_probe_inner.XXXXXX.sh)"
+
+mkdir -p "${OUTPUT_DIR}"
+
+cleanup_kwin_processes() {
+    pkill -f "kwin_wayland .*--socket ${SOCKET_PREFIX}" 2>/dev/null || true
+    sleep 0.2
+    if leftovers="$(pgrep -af "[k]win_wayland .*--socket ${SOCKET_PREFIX}" 2>/dev/null)"; then
+        printf 'leftover_check=found\n%s\n' "${leftovers}" >&2
+        return 1
+    fi
+    return 0
+}
+
+cleanup_all() {
+    cleanup_kwin_processes >/dev/null 2>&1 || true
+    rm -f "${RUNTIME_DIR}/${SOCKET_PREFIX}"* 2>/dev/null || true
+    rm -f "${PY_HELPER}" "${INNER_SCRIPT}" 2>/dev/null || true
+}
+trap cleanup_all EXIT INT TERM HUP
+
+cat >"${PY_HELPER}" <<'PY'
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import dbus
+import dbus.bus
+from PIL import Image
+
+METHODS = ("CaptureActiveScreen", "CaptureWorkspace", "CaptureArea")
+
+
+def _read_pipe(read_fd: int) -> bytes:
+    chunks: list[bytes] = []
+    try:
+        while True:
+            chunk = os.read(read_fd, 65536)
+            if not chunk:
+                break
+            chunks.append(chunk)
+    finally:
+        os.close(read_fd)
+    return b"".join(chunks)
+
+
+def _clean_field(value: object) -> str:
+    return str(value).replace("\n", " ").replace("|", "/")
+
+
+def _dbus_error(exc: dbus.DBusException) -> str:
+    return f"{exc.get_dbus_name()}: {exc.get_dbus_message()}"
+
+
+def _emit(
+    label: str,
+    method: str,
+    status: str,
+    width: int = 0,
+    height: int = 0,
+    stride: int = 0,
+    png_path: str = "",
+    png_size: int = 0,
+    error: object = "",
+) -> None:
+    print(
+        "|".join(
+            (
+                _clean_field(label),
+                _clean_field(method),
+                _clean_field(status),
+                str(width),
+                str(height),
+                str(stride),
+                _clean_field(png_path),
+                str(png_size),
+                _clean_field(error),
+            )
+        ),
+        flush=True,
+    )
+
+
+def _call_capture(iface: dbus.Interface, method: str, options: dbus.Dictionary) -> tuple[dict, bytes]:
+    read_fd, write_fd = os.pipe()
+    try:
+        try:
+            if method == "CaptureActiveScreen":
+                results = iface.CaptureActiveScreen(options, dbus.types.UnixFd(write_fd))
+            elif method == "CaptureWorkspace":
+                results = iface.CaptureWorkspace(options, dbus.types.UnixFd(write_fd))
+            elif method == "CaptureArea":
+                results = iface.CaptureArea(
+                    dbus.Int32(0),
+                    dbus.Int32(0),
+                    dbus.Int32(1),
+                    dbus.Int32(1),
+                    options,
+                    dbus.types.UnixFd(write_fd),
+                )
+            else:
+                raise ValueError(f"unknown method: {method}")
+        finally:
+            os.close(write_fd)
+    except Exception:
+        os.close(read_fd)
+        raise
+    return dict(results), _read_pipe(read_fd)
+
+
+def _capture(label: str, method: str, output_dir: Path) -> bool:
+    dbus_address = os.environ["DBUS_SESSION_BUS_ADDRESS"]
+    bus = dbus.bus.BusConnection(dbus_address)
+    screenshot_obj = bus.get_object("org.kde.KWin", "/org/kde/KWin/ScreenShot2")
+    iface = dbus.Interface(screenshot_obj, "org.kde.KWin.ScreenShot2")
+    options = dbus.Dictionary(
+        {
+            "include-cursor": dbus.Boolean(False),
+            "include-decoration": dbus.Boolean(True),
+        },
+        signature="sv",
+    )
+
+    results, data = _call_capture(iface, method, options)
+    width = int(results.get("width", 0))
+    height = int(results.get("height", 0))
+    stride = int(results.get("stride", 0))
+    png_path = output_dir / f"{label}__{method}.png"
+
+    if not data:
+        _emit(label, method, "FAIL", width, height, stride, str(png_path), 0, "no data")
+        return False
+    if width <= 0 or height <= 0 or stride <= 0:
+        _emit(label, method, "FAIL", width, height, stride, str(png_path), 0, "invalid geometry")
+        return False
+
+    image = Image.frombytes("RGBA", (width, height), data, "raw", "BGRA", stride)
+    image.save(png_path, "PNG")
+    _emit(label, method, "OK", width, height, stride, str(png_path), png_path.stat().st_size, "")
+    return True
+
+
+def main() -> int:
+    label = sys.argv[1]
+    output_dir = Path(os.environ["OUTPUT_DIR"])
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    had_failure = False
+    for method in METHODS:
+        try:
+            if not _capture(label, method, output_dir):
+                had_failure = True
+        except dbus.DBusException as exc:
+            had_failure = True
+            _emit(label, method, "FAIL", error=_dbus_error(exc))
+        except Exception as exc:  # noqa: BLE001 - probe must report and continue.
+            had_failure = True
+            _emit(label, method, "FAIL", error=f"{type(exc).__name__}: {exc}")
+    return 1 if had_failure else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+PY
+
+cat >"${INNER_SCRIPT}" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_PIDS=()
+
+cleanup_session() {
+    if ((${#APP_PIDS[@]})); then
+        kill "${APP_PIDS[@]}" 2>/dev/null || true
+        wait "${APP_PIDS[@]}" 2>/dev/null || true
+    fi
+    if [[ -n "${KWIN_PID:-}" ]]; then
+        kill "${KWIN_PID}" 2>/dev/null || true
+        wait "${KWIN_PID}" 2>/dev/null || true
+    fi
+    if [[ -n "${AT_SPI_PID:-}" ]]; then
+        kill "${AT_SPI_PID}" 2>/dev/null || true
+        wait "${AT_SPI_PID}" 2>/dev/null || true
+    fi
+    rm -f "${RUNTIME_DIR}/${SOCKET_NAME}" "${RUNTIME_DIR}/${SOCKET_NAME}.lock" 2>/dev/null || true
+}
+trap cleanup_session EXIT INT TERM HUP
+
+LOG_LABEL="${LABEL//[^A-Za-z0-9_.-]/_}"
+SCENARIO="${SCENARIO:-empty}"
+
+echo "DBUS_SESSION_BUS_ADDRESS=${DBUS_SESSION_BUS_ADDRESS}"
+echo "session_socket=${SOCKET_NAME}"
+echo "scenario=${SCENARIO}"
+
+/usr/lib/at-spi-bus-launcher --launch-immediately \
+    >/tmp/screenshot2_probe_atspi_${LOG_LABEL}.log 2>&1 &
+AT_SPI_PID=$!
+sleep 0.2
+
+dbus-update-activation-environment \
+    WAYLAND_DISPLAY="${SOCKET_NAME}" \
+    QT_QPA_PLATFORM=wayland \
+    >/dev/null 2>&1 || true
+
+env -u WAYLAND_DISPLAY -u QT_QPA_PLATFORM \
+    KDE_FULL_SESSION=true \
+    KDE_SESSION_VERSION=6 \
+    XDG_SESSION_TYPE=wayland \
+    XDG_CURRENT_DESKTOP=KDE \
+    QT_LINUX_ACCESSIBILITY_ALWAYS_ON=1 \
+    QT_ACCESSIBILITY=1 \
+    ATSPI_DBUS_IMPLEMENTATION=dbus-daemon \
+    KWIN_WAYLAND_NO_PERMISSION_CHECKS=1 \
+    KWIN_SCREENSHOT_NO_PERMISSION_CHECKS=1 \
+    ${EXTRA_ENV_ASSIGNMENTS:-} \
+    kwin_wayland --virtual --no-lockscreen \
+    --width "${WIDTH}" --height "${HEIGHT}" \
+    --socket "${SOCKET_NAME}" >/tmp/screenshot2_probe_kwin_${LOG_LABEL}.log 2>&1 &
+KWIN_PID=$!
+
+deadline=$((SECONDS + 10))
+while [[ ! -e "${RUNTIME_DIR}/${SOCKET_NAME}" ]]; do
+    if ! kill -0 "${KWIN_PID}" 2>/dev/null; then
+        echo "kwin_start_failed: $(command tail -n 20 /tmp/screenshot2_probe_kwin_${LOG_LABEL}.log 2>/dev/null || true)"
+        exit 0
+    fi
+    if ((SECONDS >= deadline)); then
+        echo "kwin_start_failed: timeout waiting for ${RUNTIME_DIR}/${SOCKET_NAME}"
+        exit 0
+    fi
+    sleep 0.1
+done
+sleep 0.5
+
+case "${SCENARIO}" in
+    empty)
+        ;;
+    kcalc)
+        WAYLAND_DISPLAY="${SOCKET_NAME}" QT_QPA_PLATFORM=wayland kcalc \
+            >/tmp/screenshot2_probe_kcalc_${LOG_LABEL}.log 2>&1 &
+        APP_PIDS+=("$!")
+        sleep 1.5
+        ;;
+    multi)
+        WAYLAND_DISPLAY="${SOCKET_NAME}" QT_QPA_PLATFORM=wayland kcalc \
+            >/tmp/screenshot2_probe_kcalc_${LOG_LABEL}.log 2>&1 &
+        APP_PIDS+=("$!")
+        WAYLAND_DISPLAY="${SOCKET_NAME}" QT_QPA_PLATFORM=wayland kdialog \
+            --title "Dialog-One" --msgbox "Dialog-One" \
+            >/tmp/screenshot2_probe_kdialog_one_${LOG_LABEL}.log 2>&1 &
+        APP_PIDS+=("$!")
+        WAYLAND_DISPLAY="${SOCKET_NAME}" QT_QPA_PLATFORM=wayland kdialog \
+            --title "Dialog-Two" --msgbox "Dialog-Two" \
+            >/tmp/screenshot2_probe_kdialog_two_${LOG_LABEL}.log 2>&1 &
+        APP_PIDS+=("$!")
+        sleep 2.0
+        ;;
+    *)
+        echo "unknown_scenario=${SCENARIO}"
+        exit 0
+        ;;
+esac
+
+python3 "${PY_HELPER}" "${LABEL}" || true
+SH
+chmod +x "${INNER_SCRIPT}"
+
+phase1_labels=(
+    "baseline"
+    "kwin_prefer_sw_qpainter"
+    "libgl_always_software"
+    "mesa_swrast"
+    "egl_surfaceless"
+    "libgl_mesa_swrast"
+    "libgl_egl_surfaceless"
+    "kwin_compose_o"
+    "kwin_compose_q"
+    "libgl_mesa_swrast_compose_o"
+)
+
+phase1_envs=(
+    ""
+    "KWIN_PREFER_SW_QPAINTER=1"
+    "LIBGL_ALWAYS_SOFTWARE=1"
+    "MESA_LOADER_DRIVER_OVERRIDE=swrast"
+    "EGL_PLATFORM=surfaceless"
+    "LIBGL_ALWAYS_SOFTWARE=1 MESA_LOADER_DRIVER_OVERRIDE=swrast"
+    "LIBGL_ALWAYS_SOFTWARE=1 EGL_PLATFORM=surfaceless"
+    "KWIN_COMPOSE=O"
+    "KWIN_COMPOSE=Q"
+    "LIBGL_ALWAYS_SOFTWARE=1 MESA_LOADER_DRIVER_OVERRIDE=swrast KWIN_COMPOSE=O"
+)
+
+phase2_scenarios=("empty" "kcalc" "multi")
+
+run_probe() {
+    local phase="$1"
+    local label="$2"
+    local scenario="$3"
+    local extra_env="$4"
+    local socket_name="$5"
+
+    echo
+    echo "## phase=${phase} label=${label} scenario=${scenario} extra_env=${extra_env:-<none>}"
+    rm -f "${RUNTIME_DIR}/${socket_name}" "${RUNTIME_DIR}/${socket_name}.lock" 2>/dev/null || true
+    LABEL="${label}" \
+    SCENARIO="${scenario}" \
+    WIDTH="${WIDTH}" \
+    HEIGHT="${HEIGHT}" \
+    SOCKET_NAME="${socket_name}" \
+    SOCKET_PREFIX="${SOCKET_PREFIX}" \
+    RUNTIME_DIR="${RUNTIME_DIR}" \
+    PY_HELPER="${PY_HELPER}" \
+    OUTPUT_DIR="${OUTPUT_DIR}" \
+    EXTRA_ENV_ASSIGNMENTS="${extra_env}" \
+    KDE_FULL_SESSION=true \
+    KDE_SESSION_VERSION=6 \
+    XDG_SESSION_TYPE=wayland \
+    XDG_CURRENT_DESKTOP=KDE \
+    QT_LINUX_ACCESSIBILITY_ALWAYS_ON=1 \
+    QT_ACCESSIBILITY=1 \
+    ATSPI_DBUS_IMPLEMENTATION=dbus-daemon \
+    KWIN_WAYLAND_NO_PERMISSION_CHECKS=1 \
+    KWIN_SCREENSHOT_NO_PERMISSION_CHECKS=1 \
+    dbus-run-session bash "${INNER_SCRIPT}" || true
+    rm -f "${RUNTIME_DIR}/${socket_name}" "${RUNTIME_DIR}/${socket_name}.lock" 2>/dev/null || true
+}
+
+echo "ScreenShot2 virtual-session feasibility probe"
+echo "kwin_version=$(kwin_wayland --version 2>&1 || true)"
+echo "session_model=fresh dbus-run-session + kwin_wayland --virtual per probe row"
+echo "required_env=KWIN_WAYLAND_NO_PERMISSION_CHECKS=1 KWIN_SCREENSHOT_NO_PERMISSION_CHECKS=1 ATSPI_DBUS_IMPLEMENTATION=dbus-daemon"
+echo "geometry=${WIDTH}x${HEIGHT}"
+echo "output_dir=${OUTPUT_DIR}"
+echo "output_format=label|method|status|width|height|stride|png_path|png_size|error"
+
+for index in "${!phase1_labels[@]}"; do
+    run_probe \
+        "1" \
+        "${phase1_labels[$index]}" \
+        "empty" \
+        "${phase1_envs[$index]}" \
+        "${SOCKET_PREFIX}-phase1-${index}"
+done
+
+for index in "${!phase2_scenarios[@]}"; do
+    scenario="${phase2_scenarios[$index]}"
+    run_probe \
+        "2" \
+        "phase2_${scenario}" \
+        "${scenario}" \
+        "" \
+        "${SOCKET_PREFIX}-phase2-${index}"
+done
+
+echo
+if cleanup_kwin_processes; then
+    echo "leftover_check=clean"
+else
+    echo "leftover_check=found"
+fi
+rm -f "${RUNTIME_DIR}/${SOCKET_PREFIX}"* 2>/dev/null || true
+echo "probe_complete output_dir=${OUTPUT_DIR}"


### PR DESCRIPTION
Wave 1 of the kwin-mcp backend overhaul. Combines two pre-implementation spikes into a single docs-only PR.

## ScreenShot2 virtual-session feasibility

`docs/design/screenshot2-virtual-feasibility.md` + `scripts/screenshot2_probe.sh`

Probe runs `kwin_wayland --virtual` with 10 env-var combinations × 3 ScreenShot2 methods, plus Phase 2 app scenarios (kcalc, kcalc + kdialog ×2 multi-window) and Phase 3 forced-compositor stress.

**Conclusion**: ScreenShot2 is the primary fast path in normal virtual KWin sessions on KWin 6.6.x. `spectacle` remains a compatibility fallback for forced-compositor failures (`KWIN_COMPOSE=O` / `KWIN_COMPOSE=Q`).

**Correction note**: This replaces an earlier (force-pushed away) commit that incorrectly reported 30/30 ScreenShot2 failures. See [@isac322's review feedback](https://github.com/isac322/kwin-mcp/pull/21#issuecomment-4376718867) for the original ground-truth that triggered re-running the probe.

## KWin scripting feasibility on KDE Plasma 6

`docs/design/kwin-scripting-feasibility.md` + `scripts/kwin_scripting_probe.sh`

Probe verifies KWin 6.6.4 `/Scripting` D-Bus interface. JS templates rewritten from KDE Plasma 6 scripting docs (no kdotool GPL-3.0 copy).

**Decision recorded**: in-memory script loading via `loadScriptFromText` is unavailable on KWin 6.6.x. The downstream window backend (PR #26) uses the `loadScript(tempfile_path, name)` pattern instead.

## README

Architecture diagram + How It Works → Screenshot Capture both reflect "KWin ScreenShot2 D-Bus (spectacle fallback)".

## Reproduction

```bash
bash scripts/screenshot2_probe.sh       # ScreenShot2 spike
bash scripts/kwin_scripting_probe.sh    # KWin scripting spike
```

## Files

- `README.md`
- `docs/design/screenshot2-virtual-feasibility.md` (new)
- `docs/design/kwin-scripting-feasibility.md` (new)
- `scripts/screenshot2_probe.sh` (new)
- `scripts/kwin_scripting_probe.sh` (new)
