### PR TITLE
Fix dependency bounds: pin mcp<2, require PyGObject>=3.54

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,8 @@ uv tool install kwin-mcp
 pip install kwin-mcp
 ```
 
+**System requirements:** PyGObject >= 3.54 builds against girepository-2.0, so Debian/Ubuntu-based distros need `libgirepository-2.0-dev` (plus standard build tools) installed before `pip install`. The optional `wl-clipboard` and `wtype` packages are required for the clipboard and Unicode-typing tools.
+
 ### From source
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,8 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "mcp>=1.0.0",
-    "PyGObject>=3.42.0",
+    "mcp>=1.0.0,<2",
+    "PyGObject>=3.54",
     "dbus-python>=1.3.2",
     "Pillow>=10.0.0",
 ]


### PR DESCRIPTION
Disregard 