### PR TITLE
fix(session): bound startup waits; pin mcp<2; isolate host DISPLAY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Segfault on Python 3.14 caused by missing `argtypes` on variadic `ei_seat_bind_capabilities` ctypes call
+- `session_start` hanging forever when KWin fails to start: startup now fails with a clear error instead (bounded stdout reader + bounded socket wait in the session wrapper)
+- Fresh installs breaking on import with mcp 2.x: `mcp` dependency is now bounded to `<2` (`FastMCP` was removed in mcp 2.0)
 
 ## [0.7.0] - 2026-03-29
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "mcp>=1.0.0",
+    "mcp>=1.0.0,<2",
     "PyGObject>=3.42.0",
     "dbus-python>=1.3.2",
     "Pillow>=10.0.0",

--- a/src/kwin_mcp/session.py
+++ b/src/kwin_mcp/session.py
@@ -80,7 +80,6 @@ class Session:
         self._app_counter: int = 0
         self._config: SessionConfig | None = None
         self._home_dir: Path | None = None
-        self._x11_display: str | None = None
 
     @property
     def is_running(self) -> bool:
@@ -157,7 +156,7 @@ class Session:
         # Read startup output from the wrapper script.
         # Expected lines: DBUS_SESSION_BUS_ADDRESS=..., READY
         # Any other lines (e.g. from D-Bus activation) are ignored.
-        dbus_address, got_ready, wrapper_x11 = self._read_startup_lines(self._process, timeout=25.0)
+        dbus_address, got_ready = self._read_startup_lines(self._process, timeout=25.0)
 
         # Wait for kwin to be ready (socket file appears)
         socket_path = Path(runtime_dir) / self._socket_name
@@ -178,10 +177,6 @@ class Session:
             screenshot_dir = self._home_dir / ".screenshots"
         else:
             screenshot_dir = Path(tempfile.mkdtemp(prefix="kwin-mcp-screenshots-"))
-
-        # The wrapper reports the X display it picked for the session's
-        # Xwayland (or None when Xwayland is not available).
-        self._x11_display = wrapper_x11
 
         self._info = SessionInfo(
             dbus_address=dbus_address,
@@ -213,15 +208,9 @@ class Session:
             env.update(extra_env)
         if self._info.dbus_address:
             env["DBUS_SESSION_BUS_ADDRESS"] = self._info.dbus_address
-        # X11 apps must land on this session's XWayland, not the host X
-        # server: replace the inherited host DISPLAY with the display KWin
-        # created for this session (socket appeared after session start).
-        if self._x11_display is not None:
-            env["DISPLAY"] = self._x11_display
-        else:
-            # No session XWayland: never leak the host DISPLAY into the
-            # isolated session.
-            env.pop("DISPLAY", None)
+        # Never leak the host DISPLAY into the isolated session: X11 apps
+        # would silently open on the user's real desktop.
+        env.pop("DISPLAY", None)
 
         # Create log file for stdout/stderr capture
         app_name = Path(command[0]).stem if command else "unknown"
@@ -332,15 +321,13 @@ class Session:
         self._home_dir = None
 
     @staticmethod
-    def _read_startup_lines(
-        process: subprocess.Popen[bytes], timeout: float
-    ) -> tuple[str, bool, str | None]:
+    def _read_startup_lines(process: subprocess.Popen[bytes], timeout: float) -> tuple[str, bool]:
         """Read wrapper startup lines with an overall deadline.
 
-        Returns ``(dbus_address, got_ready, x11_display)``. Never blocks
-        longer than ``timeout`` seconds: a wrapper that never prints
-        ``READY`` (dead KWin, missing binaries) must surface as an error
-        instead of hanging the caller forever.
+        Returns ``(dbus_address, got_ready)``. Never blocks longer than
+        ``timeout`` seconds: a wrapper that never prints ``READY`` (dead
+        KWin, missing binaries) must surface as an error instead of
+        hanging the caller forever.
         """
         import queue
         import threading
@@ -362,7 +349,6 @@ class Session:
 
         dbus_address = ""
         got_ready = False
-        x11_display: str | None = None
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             try:
@@ -381,11 +367,7 @@ class Session:
                 break
             elif text == "NOSOCKET":
                 break
-            elif text.startswith("XDISPLAY="):
-                value = text.split("=", 1)[1].strip()
-                if value.startswith(":"):
-                    x11_display = value
-        return dbus_address, got_ready, x11_display
+        return dbus_address, got_ready
 
     def _build_wrapper_script(self, config: SessionConfig) -> str:
         """Build the bash script that runs inside dbus-run-session."""
@@ -394,8 +376,8 @@ echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS"
 
 # Ensure all child processes are cleaned up on exit
 cleanup() {{
-    kill $KWIN_PID $AT_SPI_PID $XWAYLAND_PID 2>/dev/null
-    wait $KWIN_PID $AT_SPI_PID $XWAYLAND_PID 2>/dev/null
+    kill $KWIN_PID $AT_SPI_PID 2>/dev/null
+    wait $KWIN_PID $AT_SPI_PID 2>/dev/null
 }}
 trap cleanup EXIT TERM INT HUP
 
@@ -412,22 +394,6 @@ sleep 0.2
 # The socket doesn't exist yet, but portal-kde will be activated
 # only after KWin creates it.
 dbus-update-activation-environment WAYLAND_DISPLAY={self._socket_name} QT_QPA_PLATFORM=wayland
-
-# Clean stale X11 sockets/locks left by killed Xwayland servers (same
-# user), so the session Xwayland gets a deterministic display number.
-for d in $(seq 0 139); do
-    if [ -e "/tmp/.X$d-lock" ] && ! pgrep -f "Xwayland :$d " >/dev/null 2>&1; then
-        rm -f "/tmp/.X$d-lock" "/tmp/.X11-unix/X$d"
-    fi
-done
-
-# Pick a free X11 display number for the session's Xwayland.
-for d in $(seq 90 139); do
-    if [ ! -e "/tmp/.X11-unix/X$d" ] && [ ! -e "/tmp/.X$d-lock" ]; then
-        export DISPLAY=":$d"
-        break
-    fi
-done
 
 # Start KWin WITHOUT WAYLAND_DISPLAY and without DISPLAY to prevent
 # nesting attempts on the host compositor / host X server.
@@ -454,27 +420,7 @@ if [ "$SOCKET_OK" != "1" ]; then
 fi
 sleep 0.3
 
-# Standalone Xwayland bound to the session compositor (KWin 6.7 with
-# --virtual does not spawn its own). -ac: no X auth inside an isolated
-# throwaway session.
-if [ -n "$DISPLAY" ]; then
-    env WAYLAND_DISPLAY={self._socket_name} Xwayland "$DISPLAY" -rootless -ac > /dev/null 2>&1 &
-    XWAYLAND_PID=$!
-fi
-
-# Signal parent that setup is complete (XDISPLAY first: the parent stops
-# reading at READY)
-XSOCKET="/tmp/.X11-unix/X${{DISPLAY#\":\"}}"
-XSOCKET_OK=0
-for i in $(seq 1 50); do
-    [ -e "$XSOCKET" ] && {{ XSOCKET_OK=1; break; }}
-    sleep 0.1
-done
-if [ "$XSOCKET_OK" = "1" ]; then
-    echo "XDISPLAY=$DISPLAY"
-else
-    echo "XDISPLAY="
-fi
+# Signal parent that setup is complete
 echo "READY"
 
 # Block until kwin exits

--- a/src/kwin_mcp/session.py
+++ b/src/kwin_mcp/session.py
@@ -80,6 +80,7 @@ class Session:
         self._app_counter: int = 0
         self._config: SessionConfig | None = None
         self._home_dir: Path | None = None
+        self._x11_display: str | None = None
 
     @property
     def is_running(self) -> bool:
@@ -156,7 +157,7 @@ class Session:
         # Read startup output from the wrapper script.
         # Expected lines: DBUS_SESSION_BUS_ADDRESS=..., READY
         # Any other lines (e.g. from D-Bus activation) are ignored.
-        dbus_address, got_ready = self._read_startup_lines(self._process, timeout=25.0)
+        dbus_address, got_ready, wrapper_x11 = self._read_startup_lines(self._process, timeout=25.0)
 
         # Wait for kwin to be ready (socket file appears)
         socket_path = Path(runtime_dir) / self._socket_name
@@ -177,6 +178,10 @@ class Session:
             screenshot_dir = self._home_dir / ".screenshots"
         else:
             screenshot_dir = Path(tempfile.mkdtemp(prefix="kwin-mcp-screenshots-"))
+
+        # The wrapper reports the X display it picked for the session's
+        # Xwayland (or None when Xwayland is not available).
+        self._x11_display = wrapper_x11
 
         self._info = SessionInfo(
             dbus_address=dbus_address,
@@ -208,6 +213,15 @@ class Session:
             env.update(extra_env)
         if self._info.dbus_address:
             env["DBUS_SESSION_BUS_ADDRESS"] = self._info.dbus_address
+        # X11 apps must land on this session's XWayland, not the host X
+        # server: replace the inherited host DISPLAY with the display KWin
+        # created for this session (socket appeared after session start).
+        if self._x11_display is not None:
+            env["DISPLAY"] = self._x11_display
+        else:
+            # No session XWayland: never leak the host DISPLAY into the
+            # isolated session.
+            env.pop("DISPLAY", None)
 
         # Create log file for stdout/stderr capture
         app_name = Path(command[0]).stem if command else "unknown"
@@ -318,13 +332,15 @@ class Session:
         self._home_dir = None
 
     @staticmethod
-    def _read_startup_lines(process: subprocess.Popen[bytes], timeout: float) -> tuple[str, bool]:
+    def _read_startup_lines(
+        process: subprocess.Popen[bytes], timeout: float
+    ) -> tuple[str, bool, str | None]:
         """Read wrapper startup lines with an overall deadline.
 
-        Returns ``(dbus_address, got_ready)``. Never blocks longer than
-        ``timeout`` seconds: a wrapper that never prints ``READY`` (dead
-        KWin, missing binaries) must surface as an error instead of
-        hanging the caller forever.
+        Returns ``(dbus_address, got_ready, x11_display)``. Never blocks
+        longer than ``timeout`` seconds: a wrapper that never prints
+        ``READY`` (dead KWin, missing binaries) must surface as an error
+        instead of hanging the caller forever.
         """
         import queue
         import threading
@@ -346,6 +362,7 @@ class Session:
 
         dbus_address = ""
         got_ready = False
+        x11_display: str | None = None
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             try:
@@ -364,7 +381,11 @@ class Session:
                 break
             elif text == "NOSOCKET":
                 break
-        return dbus_address, got_ready
+            elif text.startswith("XDISPLAY="):
+                value = text.split("=", 1)[1].strip()
+                if value.startswith(":"):
+                    x11_display = value
+        return dbus_address, got_ready, x11_display
 
     def _build_wrapper_script(self, config: SessionConfig) -> str:
         """Build the bash script that runs inside dbus-run-session."""
@@ -373,8 +394,8 @@ echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS"
 
 # Ensure all child processes are cleaned up on exit
 cleanup() {{
-    kill $KWIN_PID $AT_SPI_PID 2>/dev/null
-    wait $KWIN_PID $AT_SPI_PID 2>/dev/null
+    kill $KWIN_PID $AT_SPI_PID $XWAYLAND_PID 2>/dev/null
+    wait $KWIN_PID $AT_SPI_PID $XWAYLAND_PID 2>/dev/null
 }}
 trap cleanup EXIT TERM INT HUP
 
@@ -392,12 +413,25 @@ sleep 0.2
 # only after KWin creates it.
 dbus-update-activation-environment WAYLAND_DISPLAY={self._socket_name} QT_QPA_PLATFORM=wayland
 
-# Start KWin WITHOUT WAYLAND_DISPLAY to prevent nesting attempt.
-# KWin with --virtual creates its own compositor, it must not try
-# to connect to another compositor as a client.
-# Explicitly pass KWIN_ permission env vars to ensure they reach the
-# KWin process (environment inheritance through dbus-run-session can be unreliable).
-env -u WAYLAND_DISPLAY -u QT_QPA_PLATFORM \
+# Clean stale X11 sockets/locks left by killed Xwayland servers (same
+# user), so the session Xwayland gets a deterministic display number.
+for d in $(seq 0 139); do
+    if [ -e "/tmp/.X$d-lock" ] && ! pgrep -f "Xwayland :$d " >/dev/null 2>&1; then
+        rm -f "/tmp/.X$d-lock" "/tmp/.X11-unix/X$d"
+    fi
+done
+
+# Pick a free X11 display number for the session's Xwayland.
+for d in $(seq 90 139); do
+    if [ ! -e "/tmp/.X11-unix/X$d" ] && [ ! -e "/tmp/.X$d-lock" ]; then
+        export DISPLAY=":$d"
+        break
+    fi
+done
+
+# Start KWin WITHOUT WAYLAND_DISPLAY and without DISPLAY to prevent
+# nesting attempts on the host compositor / host X server.
+env -u WAYLAND_DISPLAY -u DISPLAY -u QT_QPA_PLATFORM \
     KWIN_WAYLAND_NO_PERMISSION_CHECKS=1 \
     KWIN_SCREENSHOT_NO_PERMISSION_CHECKS=1 \
     kwin_wayland --virtual --no-lockscreen \
@@ -420,7 +454,27 @@ if [ "$SOCKET_OK" != "1" ]; then
 fi
 sleep 0.3
 
-# Signal parent that setup is complete
+# Standalone Xwayland bound to the session compositor (KWin 6.7 with
+# --virtual does not spawn its own). -ac: no X auth inside an isolated
+# throwaway session.
+if [ -n "$DISPLAY" ]; then
+    env WAYLAND_DISPLAY={self._socket_name} Xwayland "$DISPLAY" -rootless -ac > /dev/null 2>&1 &
+    XWAYLAND_PID=$!
+fi
+
+# Signal parent that setup is complete (XDISPLAY first: the parent stops
+# reading at READY)
+XSOCKET="/tmp/.X11-unix/X${{DISPLAY#\":\"}}"
+XSOCKET_OK=0
+for i in $(seq 1 50); do
+    [ -e "$XSOCKET" ] && {{ XSOCKET_OK=1; break; }}
+    sleep 0.1
+done
+if [ "$XSOCKET_OK" = "1" ]; then
+    echo "XDISPLAY=$DISPLAY"
+else
+    echo "XDISPLAY="
+fi
 echo "READY"
 
 # Block until kwin exits
@@ -449,6 +503,7 @@ wait $KWIN_PID
             "KWIN_WAYLAND_NO_PERMISSION_CHECKS": "1",
         }
         # Remove host display references to avoid kwin connecting to host
+        # and to keep X11 apps inside the session's own XWayland.
         env.pop("WAYLAND_DISPLAY", None)
         env.pop("DISPLAY", None)
 

--- a/src/kwin_mcp/session.py
+++ b/src/kwin_mcp/session.py
@@ -156,18 +156,7 @@ class Session:
         # Read startup output from the wrapper script.
         # Expected lines: DBUS_SESSION_BUS_ADDRESS=..., READY
         # Any other lines (e.g. from D-Bus activation) are ignored.
-        dbus_address = ""
-        got_ready = False
-        if self._process.stdout:
-            while True:
-                line = self._process.stdout.readline().decode().strip()
-                if not line and self._process.poll() is not None:
-                    break
-                if line.startswith("DBUS_SESSION_BUS_ADDRESS="):
-                    dbus_address = line.split("=", 1)[1]
-                elif line == "READY":
-                    got_ready = True
-                    break
+        dbus_address, got_ready = self._read_startup_lines(self._process, timeout=25.0)
 
         # Wait for kwin to be ready (socket file appears)
         socket_path = Path(runtime_dir) / self._socket_name
@@ -328,6 +317,55 @@ class Session:
         self._info = None
         self._home_dir = None
 
+    @staticmethod
+    def _read_startup_lines(process: subprocess.Popen[bytes], timeout: float) -> tuple[str, bool]:
+        """Read wrapper startup lines with an overall deadline.
+
+        Returns ``(dbus_address, got_ready)``. Never blocks longer than
+        ``timeout`` seconds: a wrapper that never prints ``READY`` (dead
+        KWin, missing binaries) must surface as an error instead of
+        hanging the caller forever.
+        """
+        import queue
+        import threading
+
+        lines: queue.Queue[bytes | None] = queue.Queue()
+
+        def reader() -> None:
+            try:
+                if process.stdout is not None:
+                    for line in process.stdout:
+                        lines.put(line)
+            except Exception:
+                pass
+            finally:
+                lines.put(None)
+
+        thread = threading.Thread(target=reader, daemon=True)
+        thread.start()
+
+        dbus_address = ""
+        got_ready = False
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                line = lines.get(timeout=0.2)
+            except queue.Empty:
+                if process.poll() is not None:
+                    break
+                continue
+            if line is None:
+                break
+            text = line.decode("utf-8", errors="replace").strip()
+            if text.startswith("DBUS_SESSION_BUS_ADDRESS="):
+                dbus_address = text.split("=", 1)[1]
+            elif text == "READY":
+                got_ready = True
+                break
+            elif text == "NOSOCKET":
+                break
+        return dbus_address, got_ready
+
     def _build_wrapper_script(self, config: SessionConfig) -> str:
         """Build the bash script that runs inside dbus-run-session."""
         return f"""\
@@ -367,8 +405,19 @@ env -u WAYLAND_DISPLAY -u QT_QPA_PLATFORM \
     --socket {self._socket_name} &
 KWIN_PID=$!
 
-# Wait for KWin socket to appear
-while [ ! -e "$XDG_RUNTIME_DIR/{self._socket_name}" ]; do sleep 0.1; done
+# Wait for KWin socket to appear (bounded: 150 x 0.1s = 15s max)
+SOCKET_OK=0
+for i in $(seq 1 150); do
+    if [ -e "$XDG_RUNTIME_DIR/{self._socket_name}" ]; then
+        SOCKET_OK=1
+        break
+    fi
+    sleep 0.1
+done
+if [ "$SOCKET_OK" != "1" ]; then
+    echo "NOSOCKET"
+    exit 1
+fi
 sleep 0.3
 
 # Signal parent that setup is complete

--- a/uv.lock
+++ b/uv.lock
@@ -281,7 +281,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "dbus-python", specifier = ">=1.3.2" },
-    { name = "mcp", specifier = ">=1.0.0" },
+    { name = "mcp", specifier = ">=1.0.0,<2" },
     { name = "pillow", specifier = ">=10.0.0" },
     { name = "pygobject", specifier = ">=3.42.0" },
 ]


### PR DESCRIPTION
Closes #48, closes #49. Refs #29, #39, #43, #37.

## What's done

Three targeted fixes, each verified in an isolated venv against a live virtual KWin session:

1. **Bound `session_start` waits** (`src/kwin_mcp/session.py`)
   - Parent side: stdout/READY parsing moved to a bounded reader (`_read_startup_lines`, reader-thread + 25 s deadline). A wrapper that never prints `READY` (dead KWin, missing binaries) now surfaces as a clear error instead of blocking the MCP tool call forever.
   - Wrapper side: socket wait loop bounded to 15 s; on timeout prints `NOSOCKET` and exits 1 — the parent observes process exit instead of waiting forever.
2. **Pin `mcp>=1.0.0,<2`** (`pyproject.toml`, `uv.lock`) — mcp 2.0 removed `FastMCP`, so fresh installs broke at import time (#49).
3. **Never leak host `DISPLAY`** into `launch_app` env and wrapper (`env -u DISPLAY` for `kwin_wayland --virtual`, `env.pop("DISPLAY")` for launched apps) — X11 apps launched into the session silently opened on the user's real desktop otherwise.

## Why this way

- Bounded waits at both layers (parent + wrapper) because each layer alone can hang independently: the wrapper can block on a socket that never appears, and the parent can block on `readline()` of a wrapper that died before printing `READY`.
- `mcp<2` pin instead of migrating to the new mcp API: minimal risk, unblocks installs now; migration can be a separate PR.
- Rejected alternatives: increasing default tool timeouts (doesn't help — the call never returns), killing the process from the MCP server on timeout (leaves orphaned KWin/dbus processes; NOSOCKET exit keeps the wrapper as the single owner of the process group).

## How to verify

- Happy path: `session_start` returns in ~1.3 s.
- Negative path (simulate KWin failure): `session_start` returns an error in ~15.7 s instead of hanging forever.
- Regression: fresh `uv tool install` works with mcp<2; import no longer fails on mcp 2.x environments.
- Tested on Linux (KDE Plasma Wayland host, virtual KWin session), Python 3.12.

## Out of scope / risks

- The `DISPLAY` pop changes behavior for anyone who intentionally ran X11 apps on the host display from the session — that contradicts the tool's isolation purpose, so it's a fix rather than a regression.
- The variadic-ABI segfault fix itself (#29 family) is not included here — this PR only makes startup failures observable. CFUNCTYPE approach is already covered by open PR #32.
- CHANGELOG entries included for the two bug fixes.