### PR TITLE
fix: isolate virtual-session keymap from host XDG config and XKB defaults

### DIFF
--- a/.fork_input.py
+++ b/.fork_input.py
@@ -1,0 +1,1246 @@
+"""Input injection via KWin's EIS (Emulated Input Server) D-Bus interface.
+
+Uses KWin's private org.kde.KWin.EIS.RemoteDesktop D-Bus interface to get
+a direct EIS file descriptor, then uses libei to inject mouse/keyboard
+events into the isolated kwin_wayland --virtual session.
+
+This bypasses the XDG RemoteDesktop portal (which requires user authorization)
+and communicates directly with the KWin compositor.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import ctypes
+import ctypes.util
+import select
+import shutil
+import subprocess
+import time
+from enum import Enum
+
+import dbus
+import dbus.bus
+from dbus.mainloop.glib import DBusGMainLoop
+
+from kwin_mcp.errors import tool_error
+
+
+class MouseButton(Enum):
+    LEFT = "left"
+    RIGHT = "right"
+    MIDDLE = "middle"
+
+
+# Linux input event codes for mouse buttons
+_BTN_CODES: dict[MouseButton, int] = {
+    MouseButton.LEFT: 0x110,  # BTN_LEFT
+    MouseButton.RIGHT: 0x111,  # BTN_RIGHT
+    MouseButton.MIDDLE: 0x112,  # BTN_MIDDLE
+}
+
+# Linux evdev keycodes for special keys
+_EVDEV_KEY_MAP: dict[str, int] = {
+    "return": 28,
+    "enter": 28,
+    "tab": 15,
+    "escape": 1,
+    "backspace": 14,
+    "delete": 111,
+    "space": 57,
+    "up": 103,
+    "down": 108,
+    "left": 105,
+    "right": 106,
+    "home": 102,
+    "end": 107,
+    "page_up": 104,
+    "pageup": 104,
+    "page_down": 109,
+    "pagedown": 109,
+    "insert": 110,
+    "f1": 59,
+    "f2": 60,
+    "f3": 61,
+    "f4": 62,
+    "f5": 63,
+    "f6": 64,
+    "f7": 65,
+    "f8": 66,
+    "f9": 67,
+    "f10": 68,
+    "f11": 87,
+    "f12": 88,
+    "print": 99,
+    "scroll_lock": 70,
+    "pause": 119,
+    "caps_lock": 58,
+    "num_lock": 69,
+    "menu": 127,
+}
+
+# Modifier evdev keycodes
+_MODIFIER_KEYS: dict[str, int] = {
+    "shift": 42,  # KEY_LEFTSHIFT
+    "ctrl": 29,  # KEY_LEFTCTRL
+    "control": 29,
+    "alt": 56,  # KEY_LEFTALT
+    "super": 125,  # KEY_LEFTMETA
+    "meta": 125,
+}
+
+# Character to evdev keycode mapping (US QWERTY layout)
+_CHAR_KEY_MAP: dict[str, tuple[int, bool]] = {}
+
+# Build character → (keycode, needs_shift) mapping
+_QWERTY_ROWS = [
+    # (normal_chars, shifted_chars, keycodes)
+    ("`1234567890-=", "~!@#$%^&*()_+", [41, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]),
+    ("qwertyuiop[]\\", "QWERTYUIOP{}|", [16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 43]),
+    ("asdfghjkl;'", 'ASDFGHJKL:"', [30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40]),
+    ("zxcvbnm,./", "ZXCVBNM<>?", [44, 45, 46, 47, 48, 49, 50, 51, 52, 53]),
+]
+
+for normal, shifted, codes in _QWERTY_ROWS:
+    for char, code in zip(normal, codes, strict=True):
+        _CHAR_KEY_MAP[char] = (code, False)
+    for char, code in zip(shifted, codes, strict=True):
+        _CHAR_KEY_MAP[char] = (code, True)
+
+_CHAR_KEY_MAP[" "] = (57, False)  # space
+_CHAR_KEY_MAP["\t"] = (15, False)  # tab
+_CHAR_KEY_MAP["\n"] = (28, False)  # enter
+
+# Button states
+_PRESSED = 1
+_RELEASED = 0
+
+# EI device capabilities (bitfield)
+_EI_CAP_POINTER = 1 << 0
+_EI_CAP_POINTER_ABSOLUTE = 1 << 1
+_EI_CAP_KEYBOARD = 1 << 2
+_EI_CAP_TOUCH = 1 << 3
+_EI_CAP_SCROLL = 1 << 4
+_EI_CAP_BUTTON = 1 << 5
+_EI_CAP_TEXT = 1 << 6  # libei >= 1.6: keysym/UTF-8 input resolved server-side
+
+# EI event types
+_EI_EVENT_CONNECT = 1
+_EI_EVENT_DISCONNECT = 2
+_EI_EVENT_SEAT_ADDED = 3
+_EI_EVENT_DEVICE_ADDED = 5
+_EI_EVENT_DEVICE_RESUMED = 8
+
+# Scroll axis values (in libei, scroll is in pixels)
+_SCROLL_STEP_PIXELS = 15.0
+
+# XKB keysyms for control characters (XK_Return, XK_Tab)
+_XKB_KEYSYM_RETURN = 0xFF0D
+_XKB_KEYSYM_TAB = 0xFF09
+
+# XKB keysyms for named special keys (from xkbcommon-keysyms.h). The server
+# resolves these through its own keymap, so no client-side keymap knowledge
+# is required.
+_KEYSYM_NAME_MAP: dict[str, int] = {
+    "return": _XKB_KEYSYM_RETURN,
+    "enter": _XKB_KEYSYM_RETURN,
+    "tab": _XKB_KEYSYM_TAB,
+    "escape": 0xFF1B,
+    "backspace": 0xFF08,
+    "delete": 0xFFFF,
+    "space": 0x20,
+    "up": 0xFF52,
+    "down": 0xFF54,
+    "left": 0xFF51,
+    "right": 0xFF53,
+    "home": 0xFF50,
+    "end": 0xFF57,
+    "page_up": 0xFF55,
+    "pageup": 0xFF55,
+    "page_down": 0xFF56,
+    "pagedown": 0xFF56,
+    "insert": 0xFF63,
+    "print": 0xFF61,
+    "scroll_lock": 0xFF14,
+    "pause": 0xFF13,
+    "caps_lock": 0xFFE5,
+    "num_lock": 0xFF7F,
+    "menu": 0xFF67,
+    "f1": 0xFFBE,
+    "f2": 0xFFBF,
+    "f3": 0xFFC0,
+    "f4": 0xFFC1,
+    "f5": 0xFFC2,
+    "f6": 0xFFC3,
+    "f7": 0xFFC4,
+    "f8": 0xFFC5,
+    "f9": 0xFFC6,
+    "f10": 0xFFC7,
+    "f11": 0xFFC8,
+    "f12": 0xFFC9,
+}
+
+# Printable ASCII → XKB keysym. XKB assigns Latin-1 keysyms to the same
+# codepoints as ASCII, so this table is a straight pass-through for 0x20-0x7E.
+_ASCII_TO_KEYSYM: dict[str, int] = {chr(c): c for c in range(0x20, 0x7F)}
+_ASCII_TO_KEYSYM["\n"] = _XKB_KEYSYM_RETURN
+_ASCII_TO_KEYSYM["\t"] = _XKB_KEYSYM_TAB
+
+
+def ascii_char_to_keysym(char: str) -> int | None:
+    """Map a single character to its XKB keysym, or None if not mappable."""
+    return _ASCII_TO_KEYSYM.get(char)
+
+
+def key_name_to_keysym(name: str) -> int | None:
+    """Map a key name (e.g. 'Return', 'F5') to its XKB keysym, or None."""
+    return _KEYSYM_NAME_MAP.get(name.lower())
+
+
+def _load_libei() -> ctypes.CDLL:
+    """Load libei shared library and set up function prototypes."""
+    lib = ctypes.CDLL("libei.so.1")
+
+    # Context management
+    lib.ei_new_sender.restype = ctypes.c_void_p
+    lib.ei_new_sender.argtypes = [ctypes.c_void_p]
+    lib.ei_configure_name.restype = None
+    lib.ei_configure_name.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+    lib.ei_setup_backend_fd.restype = ctypes.c_int
+    lib.ei_setup_backend_fd.argtypes = [ctypes.c_void_p, ctypes.c_int]
+    lib.ei_dispatch.restype = ctypes.c_int
+    lib.ei_dispatch.argtypes = [ctypes.c_void_p]
+    lib.ei_get_event.restype = ctypes.c_void_p
+    lib.ei_get_event.argtypes = [ctypes.c_void_p]
+    lib.ei_event_get_type.restype = ctypes.c_int
+    lib.ei_event_get_type.argtypes = [ctypes.c_void_p]
+    lib.ei_event_unref.restype = ctypes.c_void_p
+    lib.ei_event_unref.argtypes = [ctypes.c_void_p]
+    lib.ei_unref.restype = ctypes.c_void_p
+    lib.ei_unref.argtypes = [ctypes.c_void_p]
+    lib.ei_get_fd.restype = ctypes.c_int
+    lib.ei_get_fd.argtypes = [ctypes.c_void_p]
+
+    # Seat functions
+    lib.ei_event_get_seat.restype = ctypes.c_void_p
+    lib.ei_event_get_seat.argtypes = [ctypes.c_void_p]
+    lib.ei_seat_has_capability.restype = ctypes.c_int
+    lib.ei_seat_has_capability.argtypes = [ctypes.c_void_p, ctypes.c_uint]
+    lib.ei_seat_ref.restype = ctypes.c_void_p
+    lib.ei_seat_ref.argtypes = [ctypes.c_void_p]
+    lib.ei_seat_bind_capabilities.restype = None
+    lib.ei_seat_bind_capabilities.argtypes = [ctypes.c_void_p]  # variadic: fixed param only
+
+    # Device functions
+    lib.ei_event_get_device.restype = ctypes.c_void_p
+    lib.ei_event_get_device.argtypes = [ctypes.c_void_p]
+    lib.ei_device_get_name.restype = ctypes.c_char_p
+    lib.ei_device_get_name.argtypes = [ctypes.c_void_p]
+    lib.ei_device_has_capability.restype = ctypes.c_int
+    lib.ei_device_has_capability.argtypes = [ctypes.c_void_p, ctypes.c_uint]
+    lib.ei_device_ref.restype = ctypes.c_void_p
+    lib.ei_device_ref.argtypes = [ctypes.c_void_p]
+    lib.ei_device_unref.restype = ctypes.c_void_p
+    lib.ei_device_unref.argtypes = [ctypes.c_void_p]
+
+    # Input injection
+    lib.ei_device_pointer_motion.restype = None
+    lib.ei_device_pointer_motion.argtypes = [ctypes.c_void_p, ctypes.c_double, ctypes.c_double]
+    lib.ei_device_pointer_motion_absolute.restype = None
+    lib.ei_device_pointer_motion_absolute.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_double,
+        ctypes.c_double,
+    ]
+    lib.ei_device_button_button.restype = None
+    lib.ei_device_button_button.argtypes = [ctypes.c_void_p, ctypes.c_uint32, ctypes.c_int]
+    lib.ei_device_scroll_delta.restype = None
+    lib.ei_device_scroll_delta.argtypes = [ctypes.c_void_p, ctypes.c_double, ctypes.c_double]
+    lib.ei_device_scroll_discrete.restype = None
+    lib.ei_device_scroll_discrete.argtypes = [ctypes.c_void_p, ctypes.c_int32, ctypes.c_int32]
+    lib.ei_device_scroll_stop.restype = None
+    lib.ei_device_scroll_stop.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_int]
+    lib.ei_device_keyboard_key.restype = None
+    lib.ei_device_keyboard_key.argtypes = [ctypes.c_void_p, ctypes.c_uint32, ctypes.c_int]
+    lib.ei_device_frame.restype = None
+    lib.ei_device_frame.argtypes = [ctypes.c_void_p, ctypes.c_uint64]
+    lib.ei_device_start_emulating.restype = None
+    lib.ei_device_start_emulating.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
+    lib.ei_device_stop_emulating.restype = None
+    lib.ei_device_stop_emulating.argtypes = [ctypes.c_void_p]
+
+    # Text input (libei >= 1.6). Events are resolved by the server: keysyms go
+    # through the server's keymap (EisDevice::sendKeySym in KWin), UTF-8 text
+    # goes through the input method. These symbols are missing on older libei;
+    # guard with hasattr so the module still loads there.
+    if hasattr(lib, "ei_device_text_keysym"):
+        lib.ei_device_text_keysym.restype = None
+        lib.ei_device_text_keysym.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_uint32,
+            ctypes.c_int,
+        ]
+    if hasattr(lib, "ei_device_text_utf8"):
+        lib.ei_device_text_utf8.restype = None
+        lib.ei_device_text_utf8.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+
+    # Touch functions
+    lib.ei_device_touch_new.restype = ctypes.c_void_p
+    lib.ei_device_touch_new.argtypes = [ctypes.c_void_p]
+    lib.ei_touch_down.restype = None
+    lib.ei_touch_down.argtypes = [ctypes.c_void_p, ctypes.c_double, ctypes.c_double]
+    lib.ei_touch_motion.restype = None
+    lib.ei_touch_motion.argtypes = [ctypes.c_void_p, ctypes.c_double, ctypes.c_double]
+    lib.ei_touch_up.restype = None
+    lib.ei_touch_up.argtypes = [ctypes.c_void_p]
+    lib.ei_touch_unref.restype = ctypes.c_void_p
+    lib.ei_touch_unref.argtypes = [ctypes.c_void_p]
+
+    return lib
+
+
+# Module-level libei instance, loaded lazily on first use. Loading eagerly at
+# import time makes importing this module fail on systems without libei
+# installed (e.g. the CI test job, which only exercises module structure),
+# even though no EIS input path is touched there.
+_libei: ctypes.CDLL | None = None
+
+
+def _get_libei() -> ctypes.CDLL:
+    """Return the process-wide libei handle, loading it on first call."""
+    global _libei
+    if _libei is None:
+        _libei = _load_libei()
+    return _libei
+
+
+class EISClient:
+    """Low-level EIS client using KWin's direct D-Bus interface + libei.
+
+    Connects to KWin's org.kde.KWin.EIS.RemoteDesktop D-Bus interface
+    to get an EIS file descriptor, then uses libei to negotiate devices
+    and inject input events.
+    """
+
+    def __init__(self, dbus_address: str) -> None:
+        DBusGMainLoop(set_as_default=True)
+        self._bus = dbus.bus.BusConnection(dbus_address)
+        self._ei: int = 0  # ctypes void pointer (int representation)
+        self._cookie: int = 0
+        self._pointer: int = 0  # absolute pointer device
+        self._keyboard: int = 0  # keyboard device
+        self._touch_device: int = 0  # touch-capable device
+        self._text_device: int = 0  # text device (libei >= 1.6)
+        self._eis_iface: dbus.Interface | None = None
+        self._next_touch_id: int = 0  # auto-increment touch ID
+        self._active_touches: dict[int, int] = {}  # touch_id -> ctypes pointer
+        self._setup()
+
+    def _setup(self) -> None:
+        """Connect to KWin EIS and negotiate devices."""
+        eis_obj = self._bus.get_object("org.kde.KWin", "/org/kde/KWin/EIS/RemoteDesktop")
+        self._eis_iface = dbus.Interface(eis_obj, "org.kde.KWin.EIS.RemoteDesktop")
+
+        # Request all relevant capabilities
+        caps = (
+            _EI_CAP_POINTER
+            | _EI_CAP_POINTER_ABSOLUTE
+            | _EI_CAP_KEYBOARD
+            | _EI_CAP_TOUCH
+            | _EI_CAP_BUTTON
+            | _EI_CAP_SCROLL
+        )
+        result = self._eis_iface.connectToEIS(dbus.Int32(caps))
+        fd = result[0].take()
+        self._cookie = int(result[1])
+
+        # Create libei sender context
+        self._ei = _get_libei().ei_new_sender(None)
+        if not self._ei:
+            msg = "Failed to create EI context"
+            raise RuntimeError(msg)
+
+        _get_libei().ei_configure_name(self._ei, b"kwin-mcp")
+
+        ret = _get_libei().ei_setup_backend_fd(self._ei, fd)
+        if ret != 0:
+            _get_libei().ei_unref(self._ei)
+            self._ei = 0
+            msg = f"ei_setup_backend_fd failed: {ret}"
+            raise RuntimeError(msg)
+
+        # Process handshake events to get devices
+        self._negotiate_devices()
+
+    def _negotiate_devices(self, timeout: float = 5.0) -> None:
+        """Process EIS handshake events until pointer + keyboard are usable.
+
+        A libei device may only send events once the server has resumed it.
+        Calling ``ei_device_start_emulating()`` earlier is rejected ("device
+        is not emulating") and every event sent afterwards is silently
+        dropped, so wait for ``EI_EVENT_DEVICE_RESUMED`` on each of pointer
+        and keyboard before starting emulation (adapted from upstream
+        isac322/kwin-mcp#42). Unlike upstream, which falls back to an
+        unconditional start for devices that never resumed, this fork raises:
+        silent input loss is exactly what the wait exists to prevent.
+        """
+        ei_fd = _get_libei().ei_get_fd(self._ei)
+        start = time.monotonic()
+        resumed: set[int] = set()
+
+        while time.monotonic() - start < timeout:
+            readable, _, _ = select.select([ei_fd], [], [], 0.3)
+            if readable:
+                ret = _get_libei().ei_dispatch(self._ei)
+                if ret < 0:
+                    break
+
+            while True:
+                event = _get_libei().ei_get_event(self._ei)
+                if not event:
+                    break
+
+                etype = _get_libei().ei_event_get_type(event)
+
+                if etype == _EI_EVENT_DISCONNECT:
+                    _get_libei().ei_event_unref(event)
+                    msg = "EIS server disconnected during handshake"
+                    raise RuntimeError(msg)
+
+                if etype == _EI_EVENT_SEAT_ADDED:
+                    self._bind_seat_capabilities(event)
+
+                elif etype == _EI_EVENT_DEVICE_ADDED:
+                    self._register_device(event)
+
+                elif etype == _EI_EVENT_DEVICE_RESUMED:
+                    resumed.add(int(_get_libei().ei_event_get_device(event)))
+
+                _get_libei().ei_event_unref(event)
+
+            if (
+                self._pointer
+                and self._pointer in resumed
+                and self._keyboard
+                and self._keyboard in resumed
+            ):
+                break
+
+        if not self._pointer:
+            msg = "No pointer device available from EIS"
+            raise RuntimeError(msg)
+        if not self._keyboard:
+            msg = "No keyboard device available from EIS"
+            raise RuntimeError(msg)
+
+        missing = [
+            name
+            for device, name in ((self._pointer, "pointer"), (self._keyboard, "keyboard"))
+            if device not in resumed
+        ]
+        if missing:
+            tool_error(
+                f"EIS input devices did not resume within {timeout}s: {', '.join(missing)}. "
+                "Input injection would be silently dropped (libei rejects events sent to "
+                "non-resumed devices). Verify the KWin EIS RemoteDesktop interface."
+            )
+
+        # Start emulating on all devices
+        _get_libei().ei_device_start_emulating(self._pointer, 0)
+        if self._keyboard != self._pointer:
+            _get_libei().ei_device_start_emulating(self._keyboard, 0)
+        if self._touch_device and self._touch_device not in (self._pointer, self._keyboard):
+            _get_libei().ei_device_start_emulating(self._touch_device, 0)
+        if self._text_device and self._text_device not in (
+            self._pointer,
+            self._keyboard,
+            self._touch_device,
+        ):
+            _get_libei().ei_device_start_emulating(self._text_device, 0)
+
+    @property
+    def has_text_device(self) -> bool:
+        """Whether an EIS text device was negotiated (libei >= 1.6 + KWin 6.7+)."""
+        return self._text_device != 0
+
+    def _bind_seat_capabilities(self, event: int) -> None:
+        """Bind to all available capabilities on the seat."""
+        seat = _get_libei().ei_event_get_seat(event)
+
+        bind_list: list[int] = []
+        for cap in [
+            _EI_CAP_POINTER,
+            _EI_CAP_POINTER_ABSOLUTE,
+            _EI_CAP_KEYBOARD,
+            _EI_CAP_TOUCH,
+            _EI_CAP_BUTTON,
+            _EI_CAP_SCROLL,
+            _EI_CAP_TEXT,
+        ]:
+            if _get_libei().ei_seat_has_capability(seat, cap):
+                bind_list.append(cap)
+
+        # Call variadic ei_seat_bind_capabilities(seat, cap1, ..., NULL)
+        func = _get_libei().ei_seat_bind_capabilities
+        func.restype = None
+        args: list[ctypes.c_uint | ctypes.c_void_p] = [ctypes.c_uint(c) for c in bind_list]
+        args.append(ctypes.c_void_p(None))  # NULL sentinel
+        func(seat, *args)
+
+    def _register_device(self, event: int) -> None:
+        """Register a device from a DEVICE_ADDED event."""
+        device = _get_libei().ei_event_get_device(event)
+
+        has_abs = _get_libei().ei_device_has_capability(device, _EI_CAP_POINTER_ABSOLUTE)
+        has_kbd = _get_libei().ei_device_has_capability(device, _EI_CAP_KEYBOARD)
+        has_touch = _get_libei().ei_device_has_capability(device, _EI_CAP_TOUCH)
+        has_text = _get_libei().ei_device_has_capability(device, _EI_CAP_TEXT)
+
+        # Prefer absolute pointer device
+        if has_abs and not self._pointer:
+            self._pointer = _get_libei().ei_device_ref(device)
+        if has_kbd and not self._keyboard:
+            self._keyboard = _get_libei().ei_device_ref(device)
+        if has_touch and not self._touch_device:
+            self._touch_device = _get_libei().ei_device_ref(device)
+        if has_text and not self._text_device:
+            self._text_device = _get_libei().ei_device_ref(device)
+
+    def _now_us(self) -> int:
+        """Current time in microseconds."""
+        return int(time.monotonic() * 1_000_000)
+
+    def _flush(self) -> None:
+        """Dispatch pending events to send data to KWin."""
+        _get_libei().ei_dispatch(self._ei)
+
+    def pointer_move_absolute(self, x: float, y: float) -> None:
+        """Move pointer to absolute coordinates."""
+        _get_libei().ei_device_pointer_motion_absolute(self._pointer, x, y)
+        _get_libei().ei_device_frame(self._pointer, self._now_us())
+        self._flush()
+
+    def pointer_button(self, button: int, state: int) -> None:
+        """Press/release a mouse button (evdev button code)."""
+        _get_libei().ei_device_button_button(self._pointer, button, state)
+        _get_libei().ei_device_frame(self._pointer, self._now_us())
+        self._flush()
+
+    def pointer_scroll(self, dx: float, dy: float) -> None:
+        """Scroll by pixel delta."""
+        _get_libei().ei_device_scroll_delta(self._pointer, dx, dy)
+        _get_libei().ei_device_frame(self._pointer, self._now_us())
+        self._flush()
+
+    def pointer_scroll_discrete(self, dx: int, dy: int) -> None:
+        """Scroll by discrete steps (wheel ticks)."""
+        _get_libei().ei_device_scroll_discrete(self._pointer, dx, dy)
+        _get_libei().ei_device_frame(self._pointer, self._now_us())
+        self._flush()
+
+    def pointer_scroll_stop(self) -> None:
+        """Signal end of scroll."""
+        _get_libei().ei_device_scroll_stop(self._pointer, 1, 1)
+        _get_libei().ei_device_frame(self._pointer, self._now_us())
+        self._flush()
+
+    def keyboard_key(self, keycode: int, state: int) -> None:
+        """Press/release a key (evdev keycode)."""
+        _get_libei().ei_device_keyboard_key(self._keyboard, keycode, state)
+        _get_libei().ei_device_frame(self._keyboard, self._now_us())
+        self._flush()
+
+    def text_keysym(self, keysym: int, state: int) -> None:
+        """Press/release a key by XKB keysym via the EIS text device.
+
+        Requires libei >= 1.6 and a KWin EIS server with TEXT support; the
+        server resolves the keysym through its own keymap, so the client needs
+        no keymap knowledge.
+        """
+        if not self._text_device:
+            msg = "No EIS text device available (libei >= 1.6 required)"
+            raise RuntimeError(msg)
+        _get_libei().ei_device_text_keysym(self._text_device, keysym, state)
+        _get_libei().ei_device_frame(self._text_device, self._now_us())
+        self._flush()
+
+    def text_utf8(self, text: str) -> None:
+        """Send a UTF-8 string through the EIS text device.
+
+        The server injects it via its input method (KWin: inputMethod()->sendText).
+        """
+        if not self._text_device:
+            msg = "No EIS text device available (libei >= 1.6 required)"
+            raise RuntimeError(msg)
+        _get_libei().ei_device_text_utf8(self._text_device, text.encode("utf-8"))
+        _get_libei().ei_device_frame(self._text_device, self._now_us())
+        self._flush()
+
+    def touch_down(self, x: float, y: float) -> int:
+        """Start a new touch at (x, y). Returns a touch ID."""
+        device = self._touch_device or self._pointer
+        touch = _get_libei().ei_device_touch_new(device)
+        if not touch:
+            msg = "Failed to create touch object"
+            raise RuntimeError(msg)
+        _get_libei().ei_touch_down(touch, x, y)
+        _get_libei().ei_device_frame(device, self._now_us())
+        self._flush()
+
+        touch_id = self._next_touch_id
+        self._next_touch_id += 1
+        self._active_touches[touch_id] = touch
+        return touch_id
+
+    def touch_move(self, touch_id: int, x: float, y: float) -> None:
+        """Move an active touch to (x, y)."""
+        touch = self._active_touches.get(touch_id)
+        if touch is None:
+            msg = f"No active touch with ID {touch_id}"
+            raise ValueError(msg)
+        device = self._touch_device or self._pointer
+        _get_libei().ei_touch_motion(touch, x, y)
+        _get_libei().ei_device_frame(device, self._now_us())
+        self._flush()
+
+    def touch_up(self, touch_id: int) -> None:
+        """End an active touch."""
+        touch = self._active_touches.pop(touch_id, None)
+        if touch is None:
+            msg = f"No active touch with ID {touch_id}"
+            raise ValueError(msg)
+        device = self._touch_device or self._pointer
+        _get_libei().ei_touch_up(touch)
+        _get_libei().ei_device_frame(device, self._now_us())
+        _get_libei().ei_touch_unref(touch)
+        self._flush()
+
+    def close(self) -> None:
+        """Clean up EIS connection."""
+        # Release any lingering touches
+        for touch in self._active_touches.values():
+            _get_libei().ei_touch_up(touch)
+            _get_libei().ei_touch_unref(touch)
+        self._active_touches.clear()
+
+        if self._touch_device and self._touch_device not in (self._pointer, self._keyboard):
+            _get_libei().ei_device_stop_emulating(self._touch_device)
+            _get_libei().ei_device_unref(self._touch_device)
+            self._touch_device = 0
+        if self._text_device and self._text_device not in (
+            self._pointer,
+            self._keyboard,
+            self._touch_device,
+        ):
+            _get_libei().ei_device_stop_emulating(self._text_device)
+            _get_libei().ei_device_unref(self._text_device)
+            self._text_device = 0
+        if self._pointer:
+            _get_libei().ei_device_stop_emulating(self._pointer)
+            _get_libei().ei_device_unref(self._pointer)
+            self._pointer = 0
+        if self._keyboard and self._keyboard != self._pointer:
+            _get_libei().ei_device_stop_emulating(self._keyboard)
+            _get_libei().ei_device_unref(self._keyboard)
+            self._keyboard = 0
+
+        if self._eis_iface and self._cookie:
+            with contextlib.suppress(dbus.DBusException):
+                self._eis_iface.disconnect(dbus.Int32(self._cookie))
+
+        if self._ei:
+            _get_libei().ei_unref(self._ei)
+            self._ei = 0
+
+
+class InputBackend:
+    """High-level input injection for an isolated KWin session.
+
+    Wraps EISClient with convenient methods for mouse and keyboard
+    operations including click, drag, scroll, and key combos.
+    """
+
+    def __init__(self, dbus_address: str) -> None:
+        self._client = EISClient(dbus_address)
+
+    def mouse_move(self, x: int, y: int) -> None:
+        """Move mouse to absolute coordinates (hover)."""
+        self._client.pointer_move_absolute(float(x), float(y))
+
+    def mouse_click(
+        self,
+        x: int,
+        y: int,
+        button: MouseButton = MouseButton.LEFT,
+        *,
+        double: bool = False,
+        click_count: int = 1,
+        modifiers: list[str] | None = None,
+        hold_ms: int = 0,
+    ) -> None:
+        """Click at the given coordinates.
+
+        Args:
+            x, y: Coordinates to click at.
+            button: Mouse button to use.
+            double: If True, double-click (shorthand for click_count=2).
+            click_count: Number of consecutive clicks (1=single, 2=double, 3=triple).
+            modifiers: Modifier keys to hold during click (e.g. ["ctrl"], ["shift", "alt"]).
+            hold_ms: Duration to hold button pressed before release (for long-press).
+        """
+        if double and click_count == 1:
+            click_count = 2
+
+        btn_code = _BTN_CODES[button]
+        mod_codes = _resolve_modifiers(modifiers)
+
+        self.mouse_move(x, y)
+        time.sleep(0.02)
+
+        # Press modifier keys
+        for mod in mod_codes:
+            self._client.keyboard_key(mod, _PRESSED)
+            time.sleep(0.01)
+
+        for i in range(click_count):
+            if i > 0:
+                time.sleep(0.05)
+            self._client.pointer_button(btn_code, _PRESSED)
+            if hold_ms > 0 and i == click_count - 1:
+                time.sleep(max(0.01, hold_ms / 1000.0))
+            else:
+                time.sleep(0.01)
+            self._client.pointer_button(btn_code, _RELEASED)
+
+        # Release modifier keys in reverse order
+        for mod in reversed(mod_codes):
+            time.sleep(0.01)
+            self._client.keyboard_key(mod, _RELEASED)
+
+    def mouse_scroll(
+        self,
+        x: int,
+        y: int,
+        delta: int,
+        *,
+        horizontal: bool = False,
+        discrete: bool = False,
+        steps: int = 1,
+    ) -> None:
+        """Scroll at the given coordinates.
+
+        Args:
+            x, y: Coordinates to scroll at.
+            delta: Scroll amount (positive = down/right, negative = up/left).
+            horizontal: If True, scroll horizontally.
+            discrete: If True, use discrete scroll (wheel ticks) instead of smooth pixels.
+            steps: Split total delta into this many increments with 10ms intervals.
+        """
+        self.mouse_move(x, y)
+        time.sleep(0.02)
+
+        if discrete:
+            dx = delta if horizontal else 0
+            dy = delta if not horizontal else 0
+            if steps > 1:
+                for i in range(steps):
+                    frac_dx = dx // steps + (1 if i < dx % steps else 0) if dx else 0
+                    frac_dy = dy // steps + (1 if i < dy % steps else 0) if dy else 0
+                    if frac_dx or frac_dy:
+                        self._client.pointer_scroll_discrete(frac_dx, frac_dy)
+                    time.sleep(0.01)
+            else:
+                self._client.pointer_scroll_discrete(dx, dy)
+            self._client.pointer_scroll_stop()
+        else:
+            total_dx = float(delta) * _SCROLL_STEP_PIXELS if horizontal else 0.0
+            total_dy = float(delta) * _SCROLL_STEP_PIXELS if not horizontal else 0.0
+            if steps > 1:
+                step_dx = total_dx / steps
+                step_dy = total_dy / steps
+                for _ in range(steps):
+                    self._client.pointer_scroll(step_dx, step_dy)
+                    time.sleep(0.01)
+            else:
+                self._client.pointer_scroll(total_dx, total_dy)
+            self._client.pointer_scroll_stop()
+
+    def mouse_drag(
+        self,
+        from_x: int,
+        from_y: int,
+        to_x: int,
+        to_y: int,
+        button: MouseButton = MouseButton.LEFT,
+        modifiers: list[str] | None = None,
+        waypoints: list[tuple[int, int, int]] | None = None,
+    ) -> None:
+        """Drag from one point to another.
+
+        Args:
+            from_x, from_y: Starting coordinates.
+            to_x, to_y: Ending coordinates.
+            button: Mouse button to use for dragging.
+            modifiers: Modifier keys to hold during drag (e.g. ["alt"], ["ctrl"]).
+            waypoints: Intermediate points as (x, y, dwell_ms) tuples.
+        """
+        btn_code = _BTN_CODES[button]
+        mod_codes = _resolve_modifiers(modifiers)
+
+        self.mouse_move(from_x, from_y)
+        time.sleep(0.05)
+
+        # Press modifier keys
+        for mod in mod_codes:
+            self._client.keyboard_key(mod, _PRESSED)
+            time.sleep(0.01)
+
+        self._client.pointer_button(btn_code, _PRESSED)
+        time.sleep(0.02)
+
+        # Build full path: start -> waypoints -> end
+        segments: list[tuple[int, int, int, int, int]] = []  # (fx, fy, tx, ty, dwell_ms)
+        prev_x, prev_y = from_x, from_y
+        if waypoints:
+            for wx, wy, dwell_ms in waypoints:
+                segments.append((prev_x, prev_y, wx, wy, dwell_ms))
+                prev_x, prev_y = wx, wy
+        segments.append((prev_x, prev_y, to_x, to_y, 0))
+
+        for seg_fx, seg_fy, seg_tx, seg_ty, dwell_ms in segments:
+            dx = seg_tx - seg_fx
+            dy = seg_ty - seg_fy
+            steps = max(10, int((dx**2 + dy**2) ** 0.5 / 10))
+            for i in range(1, steps + 1):
+                frac = i / steps
+                cx = seg_fx + dx * frac
+                cy = seg_fy + dy * frac
+                self._client.pointer_move_absolute(cx, cy)
+                time.sleep(0.01)
+            if dwell_ms > 0:
+                time.sleep(dwell_ms / 1000.0)
+
+        time.sleep(0.02)
+        self._client.pointer_button(btn_code, _RELEASED)
+
+        # Release modifier keys in reverse order
+        for mod in reversed(mod_codes):
+            time.sleep(0.01)
+            self._client.keyboard_key(mod, _RELEASED)
+
+    def mouse_button_down(self, x: int, y: int, button: MouseButton = MouseButton.LEFT) -> None:
+        """Move to coordinates and press a mouse button without releasing.
+
+        Args:
+            x, y: Coordinates.
+            button: Mouse button to press.
+        """
+        btn_code = _BTN_CODES[button]
+        self.mouse_move(x, y)
+        time.sleep(0.02)
+        self._client.pointer_button(btn_code, _PRESSED)
+
+    def mouse_button_up(self, x: int, y: int, button: MouseButton = MouseButton.LEFT) -> None:
+        """Move to coordinates and release a mouse button.
+
+        Args:
+            x, y: Coordinates.
+            button: Mouse button to release.
+        """
+        btn_code = _BTN_CODES[button]
+        self.mouse_move(x, y)
+        time.sleep(0.02)
+        self._client.pointer_button(btn_code, _RELEASED)
+
+    def keyboard_type(self, text: str) -> None:
+        """Type a string of text character by character.
+
+        Uses the EIS text device (keysym per character, resolved server-side)
+        when available (libei >= 1.6 + KWin 6.7+). This delivers keys regardless
+        of which keymap the server uses, unlike the bare-keycode path which
+        assumes a US QWERTY keymap. Falls back to the legacy keycode path on
+        servers without TEXT support.
+        """
+        if self._client.has_text_device:
+            for char in text:
+                keysym = ascii_char_to_keysym(char)
+                if keysym is None:
+                    continue  # non-ASCII → use keyboard_type_unicode instead
+                self._client.text_keysym(keysym, _PRESSED)
+                time.sleep(0.01)
+                self._client.text_keysym(keysym, _RELEASED)
+                time.sleep(0.02)
+            return
+
+        # Legacy path: bare evdev keycodes (assumes US QWERTY keymap server-side)
+        for char in text:
+            entry = _CHAR_KEY_MAP.get(char)
+            if entry is None:
+                continue
+
+            keycode, needs_shift = entry
+            if needs_shift:
+                self._client.keyboard_key(_MODIFIER_KEYS["shift"], _PRESSED)
+                time.sleep(0.01)
+
+            self._client.keyboard_key(keycode, _PRESSED)
+            time.sleep(0.01)
+            self._client.keyboard_key(keycode, _RELEASED)
+
+            if needs_shift:
+                time.sleep(0.01)
+                self._client.keyboard_key(_MODIFIER_KEYS["shift"], _RELEASED)
+
+            time.sleep(0.02)
+
+    def _press_key_combo(self, key: str) -> None:
+        """Press one parsed modifier combo via the bare-keycode path.
+
+        This is ``keyboard_key``'s core without the ctrl+q alias dispatch, so
+        the alias can send each combo exactly once without recursing into
+        itself.
+        """
+        modifiers, keycode = _parse_key_combo(key)
+        if keycode is None:
+            return
+
+        if not modifiers and self._client.has_text_device:
+            # Text/special keys resolved server-side by keysym
+            keysym = key_name_to_keysym(key) or (
+                ascii_char_to_keysym(key) if len(key) == 1 else None
+            )
+            if keysym is not None:
+                self._client.text_keysym(keysym, _PRESSED)
+                time.sleep(0.01)
+                self._client.text_keysym(keysym, _RELEASED)
+                return
+
+        # Press modifiers
+        for mod in modifiers:
+            self._client.keyboard_key(mod, _PRESSED)
+            time.sleep(0.01)
+
+        # Press and release main key
+        self._client.keyboard_key(keycode, _PRESSED)
+        time.sleep(0.01)
+        self._client.keyboard_key(keycode, _RELEASED)
+
+        # Release modifiers in reverse order
+        for mod in reversed(modifiers):
+            time.sleep(0.01)
+            self._client.keyboard_key(mod, _RELEASED)
+
+    def keyboard_key(self, key: str) -> None:
+        """Press a key combination (e.g., 'ctrl+c', 'Return', 'alt+F4').
+
+        Supports modifier combinations with '+' separator. Bare keys (no
+        modifiers) are routed through the EIS text device when available, so
+        the server resolves them via its own keymap; modifier combos keep the
+        bare-keycode path (which works reliably for shortcuts).
+        """
+        # KDE splits window-close across two bindings by ACCEL convention:
+        # Konsole binds it to Ctrl+Shift+Q (its ACCEL convention is
+        # Ctrl+Shift), while most other KDE apps (kwrite, kcalc) bind plain
+        # Ctrl+Q — each combo is unbound in the other apps. Send both with a
+        # short pause (mirroring the paste alias below); on apps that bind
+        # only one of them the other is an inert no-op shortcut, so "quit the
+        # focused app" behaves uniformly across KDE apps.
+        if key.lower() in ("ctrl+q", "control+q", "ctrl+quit"):
+            self._press_key_combo("ctrl+q")
+            time.sleep(0.15)
+            self._press_key_combo("ctrl+shift+q")
+            return
+
+        self._press_key_combo(key)
+
+    def keyboard_key_down(self, key: str) -> None:
+        """Press (and hold) a key combination without releasing.
+
+        Useful for holding modifier keys across multiple actions.
+
+        Args:
+            key: Key to press (e.g., "ctrl", "shift+a", "alt").
+        """
+        modifiers, keycode = _parse_key_combo(key)
+
+        for mod in modifiers:
+            self._client.keyboard_key(mod, _PRESSED)
+            time.sleep(0.01)
+
+        if keycode is not None:
+            self._client.keyboard_key(keycode, _PRESSED)
+            time.sleep(0.01)
+
+    def keyboard_key_up(self, key: str) -> None:
+        """Release a previously pressed key combination.
+
+        Releases in reverse order (main key first, then modifiers).
+
+        Args:
+            key: Key to release (e.g., "ctrl", "shift+a", "alt").
+        """
+        modifiers, keycode = _parse_key_combo(key)
+
+        if keycode is not None:
+            self._client.keyboard_key(keycode, _RELEASED)
+            time.sleep(0.01)
+
+        for mod in reversed(modifiers):
+            self._client.keyboard_key(mod, _RELEASED)
+            time.sleep(0.01)
+
+    def touch_tap(self, x: int, y: int, hold_ms: int = 0) -> None:
+        """Tap at the given coordinates.
+
+        Args:
+            x, y: Coordinates to tap at.
+            hold_ms: Duration to hold before lifting (for long-press).
+        """
+        tid = self._client.touch_down(float(x), float(y))
+        if hold_ms > 0:
+            time.sleep(max(0.01, hold_ms / 1000.0))
+        else:
+            time.sleep(0.01)
+        self._client.touch_up(tid)
+
+    def touch_swipe(
+        self,
+        from_x: int,
+        from_y: int,
+        to_x: int,
+        to_y: int,
+        duration_ms: int = 300,
+    ) -> None:
+        """Swipe from one point to another.
+
+        Args:
+            from_x, from_y: Starting coordinates.
+            to_x, to_y: Ending coordinates.
+            duration_ms: Duration of the swipe in milliseconds.
+        """
+        steps = max(10, duration_ms // 10)
+        dx = to_x - from_x
+        dy = to_y - from_y
+
+        tid = self._client.touch_down(float(from_x), float(from_y))
+        step_delay = max(0.001, duration_ms / 1000.0 / steps)
+
+        for i in range(1, steps + 1):
+            frac = i / steps
+            cx = from_x + dx * frac
+            cy = from_y + dy * frac
+            self._client.touch_move(tid, cx, cy)
+            time.sleep(step_delay)
+
+        self._client.touch_up(tid)
+
+    def touch_pinch(
+        self,
+        center_x: int,
+        center_y: int,
+        start_distance: int,
+        end_distance: int,
+        duration_ms: int = 500,
+    ) -> None:
+        """Pinch gesture with two fingers.
+
+        Args:
+            center_x, center_y: Center point of the pinch.
+            start_distance: Initial distance between fingers (pixels).
+            end_distance: Final distance between fingers (pixels).
+            duration_ms: Duration of the gesture.
+        """
+        steps = max(10, duration_ms // 10)
+        step_delay = max(0.001, duration_ms / 1000.0 / steps)
+
+        # Two fingers start symmetrically on the x-axis
+        half_start = start_distance / 2.0
+        tid1 = self._client.touch_down(float(center_x - half_start), float(center_y))
+        tid2 = self._client.touch_down(float(center_x + half_start), float(center_y))
+
+        for i in range(1, steps + 1):
+            frac = i / steps
+            half = half_start + (end_distance / 2.0 - half_start) * frac
+            self._client.touch_move(tid1, float(center_x - half), float(center_y))
+            self._client.touch_move(tid2, float(center_x + half), float(center_y))
+            time.sleep(step_delay)
+
+        self._client.touch_up(tid1)
+        self._client.touch_up(tid2)
+
+    def touch_multi_swipe(
+        self,
+        from_x: int,
+        from_y: int,
+        to_x: int,
+        to_y: int,
+        fingers: int = 3,
+        duration_ms: int = 300,
+    ) -> None:
+        """Multi-finger swipe gesture.
+
+        Args:
+            from_x, from_y: Starting coordinates (center of finger group).
+            to_x, to_y: Ending coordinates.
+            fingers: Number of fingers (2-5).
+            duration_ms: Duration of the swipe.
+        """
+        steps = max(10, duration_ms // 10)
+        dx = to_x - from_x
+        dy = to_y - from_y
+        step_delay = max(0.001, duration_ms / 1000.0 / steps)
+        finger_spacing = 20  # pixels between fingers
+
+        # Start touches spread vertically around center
+        tids: list[int] = []
+        for f in range(fingers):
+            offset = (f - (fingers - 1) / 2.0) * finger_spacing
+            tid = self._client.touch_down(float(from_x), float(from_y + offset))
+            tids.append(tid)
+
+        for i in range(1, steps + 1):
+            frac = i / steps
+            cx = from_x + dx * frac
+            cy = from_y + dy * frac
+            for f, tid in enumerate(tids):
+                offset = (f - (fingers - 1) / 2.0) * finger_spacing
+                self._client.touch_move(tid, cx, cy + offset)
+            time.sleep(step_delay)
+
+        for tid in tids:
+            self._client.touch_up(tid)
+
+    def keyboard_type_unicode(
+        self,
+        text: str,
+        env: dict[str, str] | None = None,
+    ) -> bool:
+        """Type arbitrary Unicode text using wtype or clipboard fallback.
+
+        Args:
+            text: Text to type (supports non-ASCII, e.g. Korean, CJK).
+            env: Environment for the spawned tool. MUST contain the session's
+                WAYLAND_DISPLAY (and XDG_RUNTIME_DIR) so that wtype/wl-copy
+                connect to the isolated compositor instead of the host, plus
+                DBUS_SESSION_BUS_ADDRESS. If None, os.environ is used
+                (host session only — wtype will target the host compositor).
+
+        Returns:
+            True if text was typed successfully.
+
+        Note:
+            The AutomationEngine (core.py) passes its ``_session_env()`` here.
+            Previously the env was built locally without WAYLAND_DISPLAY,
+            which made wtype fail with "Wayland connection failed" in isolated
+            sessions and left the clipboard fallback unreachable (H-1).
+        """
+        if env is None:
+            env = dict(__import__("os").environ)
+
+        # Try wtype first. NOTE: kwin_wayland --virtual does NOT expose the
+        # zwp_virtual_keyboard_manager_v1 protocol wtype needs ("Compositor
+        # does not support the virtual keyboard protocol"), so in virtual
+        # sessions this branch always fails and the clipboard paste below is
+        # the primary path. It is kept for live sessions where wtype works.
+        if shutil.which("wtype"):
+            result = subprocess.run(
+                ["wtype", "--", text],
+                env=env,
+                capture_output=True,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                return True
+            # wtype failed (e.g. missing virtual-keyboard protocol) — fall
+            # through to the clipboard fallback instead of giving up.
+
+        # Clipboard paste via wl-copy + Ctrl+Shift+V, then Ctrl+V.
+        # The EIS keyboard is layout-independent for modifier combos, so this
+        # is the reliable route for non-ASCII text in virtual sessions where
+        # wtype cannot connect.
+        # Use Popen + DEVNULL to avoid pipe-blocking from wl-copy's forked child
+        if shutil.which("wl-copy"):
+            cp = subprocess.Popen(
+                ["wl-copy", "--", text],
+                env=env,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            time.sleep(0.2)  # Wait for fork to complete and offer the selection
+            if cp.poll() is None or cp.returncode == 0:
+                # Konsole binds paste to Ctrl+Shift+V (its ACCEL convention),
+                # most other apps use Ctrl+V. Send both; on apps that bind
+                # only one of them the other is a no-op shortcut.
+                self.keyboard_key("ctrl+shift+v")
+                time.sleep(0.15)
+                self.keyboard_key("ctrl+v")
+                # Terminators: in a zsh line editor the unbound Ctrl+V above
+                # arrives as ^V (quoted-insert) and silently consumes the
+                # first Return that follows it, no matter the delay (verified
+                # experimentally at 0.1-1.2s gaps). Two Enters guarantee the
+                # paste is committed: the first satisfies the quoted-insert,
+                # the second executes the pasted line (or is an empty
+                # command — harmless in shells and inert in GUI apps).
+                time.sleep(0.5)
+                self.keyboard_key("return")
+                time.sleep(0.3)
+                self.keyboard_key("return")
+                return True
+
+        return False
+
+    def close(self) -> None:
+        """Close the EIS connection."""
+        self._client.close()
+
+
+def _key_name_to_evdev(name: str) -> int | None:
+    """Convert a key name to its Linux evdev keycode."""
+    lower = name.lower()
+
+    if lower in _EVDEV_KEY_MAP:
+        return _EVDEV_KEY_MAP[lower]
+
+    # Single character → look up in character map
+    if len(name) == 1:
+        entry = _CHAR_KEY_MAP.get(name)
+        if entry:
+            return entry[0]
+
+    return None
+
+
+def _resolve_modifiers(modifiers: list[str] | None) -> list[int]:
+    """Resolve modifier key names to evdev keycodes."""
+    if not modifiers:
+        return []
+    codes: list[int] = []
+    for mod in modifiers:
+        code = _MODIFIER_KEYS.get(mod.lower())
+        if code is not None:
+            codes.append(code)
+    return codes
+
+
+def _parse_key_combo(key: str) -> tuple[list[int], int | None]:
+    """Parse a key combo string into (modifier_codes, main_keycode).
+
+    Returns a tuple of (list of modifier evdev keycodes, main key evdev keycode or None).
+    """
+    parts = key.split("+")
+    modifiers: list[int] = []
+    main_key: str | None = None
+
+    for part in parts:
+        part_lower = part.strip().lower()
+        if part_lower in _MODIFIER_KEYS:
+            modifiers.append(_MODIFIER_KEYS[part_lower])
+        else:
+            main_key = part.strip()
+
+    keycode: int | None = None
+    if main_key is not None:
+        keycode = _key_name_to_evdev(main_key)
+
+    return modifiers, keycode

--- a/.upstream_input.py
+++ b/.upstream_input.py
@@ -1,0 +1,982 @@
+"""Input injection via KWin's EIS (Emulated Input Server) D-Bus interface.
+
+Uses KWin's private org.kde.KWin.EIS.RemoteDesktop D-Bus interface to get
+a direct EIS file descriptor, then uses libei to inject mouse/keyboard
+events into the isolated kwin_wayland --virtual session.
+
+This bypasses the XDG RemoteDesktop portal (which requires user authorization)
+and communicates directly with the KWin compositor.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import ctypes
+import ctypes.util
+import select
+import shutil
+import subprocess
+import time
+from enum import Enum
+
+import dbus
+from dbus.mainloop.glib import DBusGMainLoop
+
+
+class MouseButton(Enum):
+    LEFT = "left"
+    RIGHT = "right"
+    MIDDLE = "middle"
+
+
+# Linux input event codes for mouse buttons
+_BTN_CODES: dict[MouseButton, int] = {
+    MouseButton.LEFT: 0x110,  # BTN_LEFT
+    MouseButton.RIGHT: 0x111,  # BTN_RIGHT
+    MouseButton.MIDDLE: 0x112,  # BTN_MIDDLE
+}
+
+# Linux evdev keycodes for special keys
+_EVDEV_KEY_MAP: dict[str, int] = {
+    "return": 28,
+    "enter": 28,
+    "tab": 15,
+    "escape": 1,
+    "backspace": 14,
+    "delete": 111,
+    "space": 57,
+    "up": 103,
+    "down": 108,
+    "left": 105,
+    "right": 106,
+    "home": 102,
+    "end": 107,
+    "page_up": 104,
+    "pageup": 104,
+    "page_down": 109,
+    "pagedown": 109,
+    "insert": 110,
+    "f1": 59,
+    "f2": 60,
+    "f3": 61,
+    "f4": 62,
+    "f5": 63,
+    "f6": 64,
+    "f7": 65,
+    "f8": 66,
+    "f9": 67,
+    "f10": 68,
+    "f11": 87,
+    "f12": 88,
+    "print": 99,
+    "scroll_lock": 70,
+    "pause": 119,
+    "caps_lock": 58,
+    "num_lock": 69,
+    "menu": 127,
+}
+
+# Modifier evdev keycodes
+_MODIFIER_KEYS: dict[str, int] = {
+    "shift": 42,  # KEY_LEFTSHIFT
+    "ctrl": 29,  # KEY_LEFTCTRL
+    "control": 29,
+    "alt": 56,  # KEY_LEFTALT
+    "super": 125,  # KEY_LEFTMETA
+    "meta": 125,
+}
+
+# Character to evdev keycode mapping (US QWERTY layout)
+_CHAR_KEY_MAP: dict[str, tuple[int, bool]] = {}
+
+# Build character → (keycode, needs_shift) mapping
+_QWERTY_ROWS = [
+    # (normal_chars, shifted_chars, keycodes)
+    ("`1234567890-=", "~!@#$%^&*()_+", [41, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]),
+    ("qwertyuiop[]\\", "QWERTYUIOP{}|", [16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 43]),
+    ("asdfghjkl;'", 'ASDFGHJKL:"', [30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40]),
+    ("zxcvbnm,./", "ZXCVBNM<>?", [44, 45, 46, 47, 48, 49, 50, 51, 52, 53]),
+]
+
+for normal, shifted, codes in _QWERTY_ROWS:
+    for char, code in zip(normal, codes, strict=True):
+        _CHAR_KEY_MAP[char] = (code, False)
+    for char, code in zip(shifted, codes, strict=True):
+        _CHAR_KEY_MAP[char] = (code, True)
+
+_CHAR_KEY_MAP[" "] = (57, False)  # space
+_CHAR_KEY_MAP["\t"] = (15, False)  # tab
+_CHAR_KEY_MAP["\n"] = (28, False)  # enter
+
+# Button states
+_PRESSED = 1
+_RELEASED = 0
+
+# EI device capabilities (bitfield)
+_EI_CAP_POINTER = 1 << 0
+_EI_CAP_POINTER_ABSOLUTE = 1 << 1
+_EI_CAP_KEYBOARD = 1 << 2
+_EI_CAP_TOUCH = 1 << 3
+_EI_CAP_SCROLL = 1 << 4
+_EI_CAP_BUTTON = 1 << 5
+
+# EI event types
+_EI_EVENT_CONNECT = 1
+_EI_EVENT_DISCONNECT = 2
+_EI_EVENT_SEAT_ADDED = 3
+_EI_EVENT_DEVICE_ADDED = 5
+_EI_EVENT_DEVICE_RESUMED = 8
+
+# Scroll axis values (in libei, scroll is in pixels)
+_SCROLL_STEP_PIXELS = 15.0
+
+
+def _load_libei() -> ctypes.CDLL:
+    """Load libei shared library and set up function prototypes."""
+    lib = ctypes.CDLL("libei.so.1")
+
+    # Context management
+    lib.ei_new_sender.restype = ctypes.c_void_p
+    lib.ei_new_sender.argtypes = [ctypes.c_void_p]
+    lib.ei_configure_name.restype = None
+    lib.ei_configure_name.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+    lib.ei_setup_backend_fd.restype = ctypes.c_int
+    lib.ei_setup_backend_fd.argtypes = [ctypes.c_void_p, ctypes.c_int]
+    lib.ei_dispatch.restype = ctypes.c_int
+    lib.ei_dispatch.argtypes = [ctypes.c_void_p]
+    lib.ei_get_event.restype = ctypes.c_void_p
+    lib.ei_get_event.argtypes = [ctypes.c_void_p]
+    lib.ei_event_get_type.restype = ctypes.c_int
+    lib.ei_event_get_type.argtypes = [ctypes.c_void_p]
+    lib.ei_event_unref.restype = ctypes.c_void_p
+    lib.ei_event_unref.argtypes = [ctypes.c_void_p]
+    lib.ei_unref.restype = ctypes.c_void_p
+    lib.ei_unref.argtypes = [ctypes.c_void_p]
+    lib.ei_get_fd.restype = ctypes.c_int
+    lib.ei_get_fd.argtypes = [ctypes.c_void_p]
+
+    # Seat functions
+    lib.ei_event_get_seat.restype = ctypes.c_void_p
+    lib.ei_event_get_seat.argtypes = [ctypes.c_void_p]
+    lib.ei_seat_has_capability.restype = ctypes.c_int
+    lib.ei_seat_has_capability.argtypes = [ctypes.c_void_p, ctypes.c_uint]
+    lib.ei_seat_ref.restype = ctypes.c_void_p
+    lib.ei_seat_ref.argtypes = [ctypes.c_void_p]
+    lib.ei_seat_bind_capabilities.restype = None
+    lib.ei_seat_bind_capabilities.argtypes = [ctypes.c_void_p]  # variadic: fixed param only
+
+    # Device functions
+    lib.ei_event_get_device.restype = ctypes.c_void_p
+    lib.ei_event_get_device.argtypes = [ctypes.c_void_p]
+    lib.ei_device_get_name.restype = ctypes.c_char_p
+    lib.ei_device_get_name.argtypes = [ctypes.c_void_p]
+    lib.ei_device_has_capability.restype = ctypes.c_int
+    lib.ei_device_has_capability.argtypes = [ctypes.c_void_p, ctypes.c_uint]
+    lib.ei_device_ref.restype = ctypes.c_void_p
+    lib.ei_device_ref.argtypes = [ctypes.c_void_p]
+    lib.ei_device_unref.restype = ctypes.c_void_p
+    lib.ei_device_unref.argtypes = [ctypes.c_void_p]
+
+    # Input injection
+    lib.ei_device_pointer_motion.restype = None
+    lib.ei_device_pointer_motion.argtypes = [ctypes.c_void_p, ctypes.c_double, ctypes.c_double]
+    lib.ei_device_pointer_motion_absolute.restype = None
+    lib.ei_device_pointer_motion_absolute.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_double,
+        ctypes.c_double,
+    ]
+    lib.ei_device_button_button.restype = None
+    lib.ei_device_button_button.argtypes = [ctypes.c_void_p, ctypes.c_uint32, ctypes.c_int]
+    lib.ei_device_scroll_delta.restype = None
+    lib.ei_device_scroll_delta.argtypes = [ctypes.c_void_p, ctypes.c_double, ctypes.c_double]
+    lib.ei_device_scroll_discrete.restype = None
+    lib.ei_device_scroll_discrete.argtypes = [ctypes.c_void_p, ctypes.c_int32, ctypes.c_int32]
+    lib.ei_device_scroll_stop.restype = None
+    lib.ei_device_scroll_stop.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_int]
+    lib.ei_device_keyboard_key.restype = None
+    lib.ei_device_keyboard_key.argtypes = [ctypes.c_void_p, ctypes.c_uint32, ctypes.c_int]
+    lib.ei_device_frame.restype = None
+    lib.ei_device_frame.argtypes = [ctypes.c_void_p, ctypes.c_uint64]
+    lib.ei_device_start_emulating.restype = None
+    lib.ei_device_start_emulating.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
+    lib.ei_device_stop_emulating.restype = None
+    lib.ei_device_stop_emulating.argtypes = [ctypes.c_void_p]
+
+    # Touch functions
+    lib.ei_device_touch_new.restype = ctypes.c_void_p
+    lib.ei_device_touch_new.argtypes = [ctypes.c_void_p]
+    lib.ei_touch_down.restype = None
+    lib.ei_touch_down.argtypes = [ctypes.c_void_p, ctypes.c_double, ctypes.c_double]
+    lib.ei_touch_motion.restype = None
+    lib.ei_touch_motion.argtypes = [ctypes.c_void_p, ctypes.c_double, ctypes.c_double]
+    lib.ei_touch_up.restype = None
+    lib.ei_touch_up.argtypes = [ctypes.c_void_p]
+    lib.ei_touch_unref.restype = ctypes.c_void_p
+    lib.ei_touch_unref.argtypes = [ctypes.c_void_p]
+
+    return lib
+
+
+# Module-level libei instance (loaded once)
+_libei = _load_libei()
+
+
+class EISClient:
+    """Low-level EIS client using KWin's direct D-Bus interface + libei.
+
+    Connects to KWin's org.kde.KWin.EIS.RemoteDesktop D-Bus interface
+    to get an EIS file descriptor, then uses libei to negotiate devices
+    and inject input events.
+    """
+
+    def __init__(self, dbus_address: str) -> None:
+        DBusGMainLoop(set_as_default=True)
+        self._bus = dbus.bus.BusConnection(dbus_address)
+        self._ei: int = 0  # ctypes void pointer (int representation)
+        self._cookie: int = 0
+        self._pointer: int = 0  # absolute pointer device
+        self._keyboard: int = 0  # keyboard device
+        self._touch_device: int = 0  # touch-capable device
+        self._eis_iface: dbus.Interface | None = None
+        self._next_touch_id: int = 0  # auto-increment touch ID
+        self._active_touches: dict[int, int] = {}  # touch_id -> ctypes pointer
+        self._setup()
+
+    def _setup(self) -> None:
+        """Connect to KWin EIS and negotiate devices."""
+        eis_obj = self._bus.get_object("org.kde.KWin", "/org/kde/KWin/EIS/RemoteDesktop")
+        self._eis_iface = dbus.Interface(eis_obj, "org.kde.KWin.EIS.RemoteDesktop")
+
+        # Request all relevant capabilities
+        caps = (
+            _EI_CAP_POINTER
+            | _EI_CAP_POINTER_ABSOLUTE
+            | _EI_CAP_KEYBOARD
+            | _EI_CAP_TOUCH
+            | _EI_CAP_BUTTON
+            | _EI_CAP_SCROLL
+        )
+        result = self._eis_iface.connectToEIS(dbus.Int32(caps))
+        fd = result[0].take()
+        self._cookie = int(result[1])
+
+        # Create libei sender context
+        self._ei = _libei.ei_new_sender(None)
+        if not self._ei:
+            msg = "Failed to create EI context"
+            raise RuntimeError(msg)
+
+        _libei.ei_configure_name(self._ei, b"kwin-mcp")
+
+        ret = _libei.ei_setup_backend_fd(self._ei, fd)
+        if ret != 0:
+            _libei.ei_unref(self._ei)
+            self._ei = 0
+            msg = f"ei_setup_backend_fd failed: {ret}"
+            raise RuntimeError(msg)
+
+        # Process handshake events to get devices
+        self._negotiate_devices()
+
+    def _negotiate_devices(self, timeout: float = 5.0) -> None:
+        """Process EIS handshake events until we have pointer + keyboard."""
+        ei_fd = _libei.ei_get_fd(self._ei)
+        start = time.monotonic()
+
+        while time.monotonic() - start < timeout:
+            readable, _, _ = select.select([ei_fd], [], [], 0.3)
+            if readable:
+                ret = _libei.ei_dispatch(self._ei)
+                if ret < 0:
+                    break
+
+            while True:
+                event = _libei.ei_get_event(self._ei)
+                if not event:
+                    break
+
+                etype = _libei.ei_event_get_type(event)
+
+                if etype == _EI_EVENT_DISCONNECT:
+                    _libei.ei_event_unref(event)
+                    msg = "EIS server disconnected during handshake"
+                    raise RuntimeError(msg)
+
+                if etype == _EI_EVENT_SEAT_ADDED:
+                    self._bind_seat_capabilities(event)
+
+                elif etype == _EI_EVENT_DEVICE_ADDED:
+                    self._register_device(event)
+
+                elif etype == _EI_EVENT_DEVICE_RESUMED:
+                    pass  # Device ready for input
+
+                _libei.ei_event_unref(event)
+
+            if self._pointer and self._keyboard:
+                break
+
+        if not self._pointer:
+            msg = "No pointer device available from EIS"
+            raise RuntimeError(msg)
+        if not self._keyboard:
+            msg = "No keyboard device available from EIS"
+            raise RuntimeError(msg)
+
+        # Start emulating on all devices
+        _libei.ei_device_start_emulating(self._pointer, 0)
+        if self._keyboard != self._pointer:
+            _libei.ei_device_start_emulating(self._keyboard, 0)
+        if self._touch_device and self._touch_device not in (self._pointer, self._keyboard):
+            _libei.ei_device_start_emulating(self._touch_device, 0)
+
+    def _bind_seat_capabilities(self, event: int) -> None:
+        """Bind to all available capabilities on the seat."""
+        seat = _libei.ei_event_get_seat(event)
+
+        bind_list: list[int] = []
+        for cap in [
+            _EI_CAP_POINTER,
+            _EI_CAP_POINTER_ABSOLUTE,
+            _EI_CAP_KEYBOARD,
+            _EI_CAP_TOUCH,
+            _EI_CAP_BUTTON,
+            _EI_CAP_SCROLL,
+        ]:
+            if _libei.ei_seat_has_capability(seat, cap):
+                bind_list.append(cap)
+
+        # Call variadic ei_seat_bind_capabilities(seat, cap1, ..., NULL)
+        func = _libei.ei_seat_bind_capabilities
+        func.restype = None
+        args: list[ctypes.c_uint | ctypes.c_void_p] = [ctypes.c_uint(c) for c in bind_list]
+        args.append(ctypes.c_void_p(None))  # NULL sentinel
+        func(seat, *args)
+
+    def _register_device(self, event: int) -> None:
+        """Register a device from a DEVICE_ADDED event."""
+        device = _libei.ei_event_get_device(event)
+
+        has_abs = _libei.ei_device_has_capability(device, _EI_CAP_POINTER_ABSOLUTE)
+        has_kbd = _libei.ei_device_has_capability(device, _EI_CAP_KEYBOARD)
+        has_touch = _libei.ei_device_has_capability(device, _EI_CAP_TOUCH)
+
+        # Prefer absolute pointer device
+        if has_abs and not self._pointer:
+            self._pointer = _libei.ei_device_ref(device)
+        if has_kbd and not self._keyboard:
+            self._keyboard = _libei.ei_device_ref(device)
+        if has_touch and not self._touch_device:
+            self._touch_device = _libei.ei_device_ref(device)
+
+    def _now_us(self) -> int:
+        """Current time in microseconds."""
+        return int(time.monotonic() * 1_000_000)
+
+    def _flush(self) -> None:
+        """Dispatch pending events to send data to KWin."""
+        _libei.ei_dispatch(self._ei)
+
+    def pointer_move_absolute(self, x: float, y: float) -> None:
+        """Move pointer to absolute coordinates."""
+        _libei.ei_device_pointer_motion_absolute(self._pointer, x, y)
+        _libei.ei_device_frame(self._pointer, self._now_us())
+        self._flush()
+
+    def pointer_button(self, button: int, state: int) -> None:
+        """Press/release a mouse button (evdev button code)."""
+        _libei.ei_device_button_button(self._pointer, button, state)
+        _libei.ei_device_frame(self._pointer, self._now_us())
+        self._flush()
+
+    def pointer_scroll(self, dx: float, dy: float) -> None:
+        """Scroll by pixel delta."""
+        _libei.ei_device_scroll_delta(self._pointer, dx, dy)
+        _libei.ei_device_frame(self._pointer, self._now_us())
+        self._flush()
+
+    def pointer_scroll_discrete(self, dx: int, dy: int) -> None:
+        """Scroll by discrete steps (wheel ticks)."""
+        _libei.ei_device_scroll_discrete(self._pointer, dx, dy)
+        _libei.ei_device_frame(self._pointer, self._now_us())
+        self._flush()
+
+    def pointer_scroll_stop(self) -> None:
+        """Signal end of scroll."""
+        _libei.ei_device_scroll_stop(self._pointer, 1, 1)
+        _libei.ei_device_frame(self._pointer, self._now_us())
+        self._flush()
+
+    def keyboard_key(self, keycode: int, state: int) -> None:
+        """Press/release a key (evdev keycode)."""
+        _libei.ei_device_keyboard_key(self._keyboard, keycode, state)
+        _libei.ei_device_frame(self._keyboard, self._now_us())
+        self._flush()
+
+    def touch_down(self, x: float, y: float) -> int:
+        """Start a new touch at (x, y). Returns a touch ID."""
+        device = self._touch_device or self._pointer
+        touch = _libei.ei_device_touch_new(device)
+        if not touch:
+            msg = "Failed to create touch object"
+            raise RuntimeError(msg)
+        _libei.ei_touch_down(touch, x, y)
+        _libei.ei_device_frame(device, self._now_us())
+        self._flush()
+
+        touch_id = self._next_touch_id
+        self._next_touch_id += 1
+        self._active_touches[touch_id] = touch
+        return touch_id
+
+    def touch_move(self, touch_id: int, x: float, y: float) -> None:
+        """Move an active touch to (x, y)."""
+        touch = self._active_touches.get(touch_id)
+        if touch is None:
+            msg = f"No active touch with ID {touch_id}"
+            raise ValueError(msg)
+        device = self._touch_device or self._pointer
+        _libei.ei_touch_motion(touch, x, y)
+        _libei.ei_device_frame(device, self._now_us())
+        self._flush()
+
+    def touch_up(self, touch_id: int) -> None:
+        """End an active touch."""
+        touch = self._active_touches.pop(touch_id, None)
+        if touch is None:
+            msg = f"No active touch with ID {touch_id}"
+            raise ValueError(msg)
+        device = self._touch_device or self._pointer
+        _libei.ei_touch_up(touch)
+        _libei.ei_device_frame(device, self._now_us())
+        _libei.ei_touch_unref(touch)
+        self._flush()
+
+    def close(self) -> None:
+        """Clean up EIS connection."""
+        # Release any lingering touches
+        for touch in self._active_touches.values():
+            _libei.ei_touch_up(touch)
+            _libei.ei_touch_unref(touch)
+        self._active_touches.clear()
+
+        if self._touch_device and self._touch_device not in (self._pointer, self._keyboard):
+            _libei.ei_device_stop_emulating(self._touch_device)
+            _libei.ei_device_unref(self._touch_device)
+            self._touch_device = 0
+        if self._pointer:
+            _libei.ei_device_stop_emulating(self._pointer)
+            _libei.ei_device_unref(self._pointer)
+            self._pointer = 0
+        if self._keyboard and self._keyboard != self._pointer:
+            _libei.ei_device_stop_emulating(self._keyboard)
+            _libei.ei_device_unref(self._keyboard)
+            self._keyboard = 0
+
+        if self._eis_iface and self._cookie:
+            with contextlib.suppress(dbus.DBusException):
+                self._eis_iface.disconnect(dbus.Int32(self._cookie))
+
+        if self._ei:
+            _libei.ei_unref(self._ei)
+            self._ei = 0
+
+
+class InputBackend:
+    """High-level input injection for an isolated KWin session.
+
+    Wraps EISClient with convenient methods for mouse and keyboard
+    operations including click, drag, scroll, and key combos.
+    """
+
+    def __init__(self, dbus_address: str) -> None:
+        self._client = EISClient(dbus_address)
+
+    def mouse_move(self, x: int, y: int) -> None:
+        """Move mouse to absolute coordinates (hover)."""
+        self._client.pointer_move_absolute(float(x), float(y))
+
+    def mouse_click(
+        self,
+        x: int,
+        y: int,
+        button: MouseButton = MouseButton.LEFT,
+        *,
+        double: bool = False,
+        click_count: int = 1,
+        modifiers: list[str] | None = None,
+        hold_ms: int = 0,
+    ) -> None:
+        """Click at the given coordinates.
+
+        Args:
+            x, y: Coordinates to click at.
+            button: Mouse button to use.
+            double: If True, double-click (shorthand for click_count=2).
+            click_count: Number of consecutive clicks (1=single, 2=double, 3=triple).
+            modifiers: Modifier keys to hold during click (e.g. ["ctrl"], ["shift", "alt"]).
+            hold_ms: Duration to hold button pressed before release (for long-press).
+        """
+        if double and click_count == 1:
+            click_count = 2
+
+        btn_code = _BTN_CODES[button]
+        mod_codes = _resolve_modifiers(modifiers)
+
+        self.mouse_move(x, y)
+        time.sleep(0.02)
+
+        # Press modifier keys
+        for mod in mod_codes:
+            self._client.keyboard_key(mod, _PRESSED)
+            time.sleep(0.01)
+
+        for i in range(click_count):
+            if i > 0:
+                time.sleep(0.05)
+            self._client.pointer_button(btn_code, _PRESSED)
+            if hold_ms > 0 and i == click_count - 1:
+                time.sleep(max(0.01, hold_ms / 1000.0))
+            else:
+                time.sleep(0.01)
+            self._client.pointer_button(btn_code, _RELEASED)
+
+        # Release modifier keys in reverse order
+        for mod in reversed(mod_codes):
+            time.sleep(0.01)
+            self._client.keyboard_key(mod, _RELEASED)
+
+    def mouse_scroll(
+        self,
+        x: int,
+        y: int,
+        delta: int,
+        *,
+        horizontal: bool = False,
+        discrete: bool = False,
+        steps: int = 1,
+    ) -> None:
+        """Scroll at the given coordinates.
+
+        Args:
+            x, y: Coordinates to scroll at.
+            delta: Scroll amount (positive = down/right, negative = up/left).
+            horizontal: If True, scroll horizontally.
+            discrete: If True, use discrete scroll (wheel ticks) instead of smooth pixels.
+            steps: Split total delta into this many increments with 10ms intervals.
+        """
+        self.mouse_move(x, y)
+        time.sleep(0.02)
+
+        if discrete:
+            dx = delta if horizontal else 0
+            dy = delta if not horizontal else 0
+            if steps > 1:
+                for i in range(steps):
+                    frac_dx = dx // steps + (1 if i < dx % steps else 0) if dx else 0
+                    frac_dy = dy // steps + (1 if i < dy % steps else 0) if dy else 0
+                    if frac_dx or frac_dy:
+                        self._client.pointer_scroll_discrete(frac_dx, frac_dy)
+                    time.sleep(0.01)
+            else:
+                self._client.pointer_scroll_discrete(dx, dy)
+            self._client.pointer_scroll_stop()
+        else:
+            total_dx = float(delta) * _SCROLL_STEP_PIXELS if horizontal else 0.0
+            total_dy = float(delta) * _SCROLL_STEP_PIXELS if not horizontal else 0.0
+            if steps > 1:
+                step_dx = total_dx / steps
+                step_dy = total_dy / steps
+                for _ in range(steps):
+                    self._client.pointer_scroll(step_dx, step_dy)
+                    time.sleep(0.01)
+            else:
+                self._client.pointer_scroll(total_dx, total_dy)
+            self._client.pointer_scroll_stop()
+
+    def mouse_drag(
+        self,
+        from_x: int,
+        from_y: int,
+        to_x: int,
+        to_y: int,
+        button: MouseButton = MouseButton.LEFT,
+        modifiers: list[str] | None = None,
+        waypoints: list[tuple[int, int, int]] | None = None,
+    ) -> None:
+        """Drag from one point to another.
+
+        Args:
+            from_x, from_y: Starting coordinates.
+            to_x, to_y: Ending coordinates.
+            button: Mouse button to use for dragging.
+            modifiers: Modifier keys to hold during drag (e.g. ["alt"], ["ctrl"]).
+            waypoints: Intermediate points as (x, y, dwell_ms) tuples.
+        """
+        btn_code = _BTN_CODES[button]
+        mod_codes = _resolve_modifiers(modifiers)
+
+        self.mouse_move(from_x, from_y)
+        time.sleep(0.05)
+
+        # Press modifier keys
+        for mod in mod_codes:
+            self._client.keyboard_key(mod, _PRESSED)
+            time.sleep(0.01)
+
+        self._client.pointer_button(btn_code, _PRESSED)
+        time.sleep(0.02)
+
+        # Build full path: start -> waypoints -> end
+        segments: list[tuple[int, int, int, int, int]] = []  # (fx, fy, tx, ty, dwell_ms)
+        prev_x, prev_y = from_x, from_y
+        if waypoints:
+            for wx, wy, dwell_ms in waypoints:
+                segments.append((prev_x, prev_y, wx, wy, dwell_ms))
+                prev_x, prev_y = wx, wy
+        segments.append((prev_x, prev_y, to_x, to_y, 0))
+
+        for seg_fx, seg_fy, seg_tx, seg_ty, dwell_ms in segments:
+            dx = seg_tx - seg_fx
+            dy = seg_ty - seg_fy
+            steps = max(10, int((dx**2 + dy**2) ** 0.5 / 10))
+            for i in range(1, steps + 1):
+                frac = i / steps
+                cx = seg_fx + dx * frac
+                cy = seg_fy + dy * frac
+                self._client.pointer_move_absolute(cx, cy)
+                time.sleep(0.01)
+            if dwell_ms > 0:
+                time.sleep(dwell_ms / 1000.0)
+
+        time.sleep(0.02)
+        self._client.pointer_button(btn_code, _RELEASED)
+
+        # Release modifier keys in reverse order
+        for mod in reversed(mod_codes):
+            time.sleep(0.01)
+            self._client.keyboard_key(mod, _RELEASED)
+
+    def mouse_button_down(self, x: int, y: int, button: MouseButton = MouseButton.LEFT) -> None:
+        """Move to coordinates and press a mouse button without releasing.
+
+        Args:
+            x, y: Coordinates.
+            button: Mouse button to press.
+        """
+        btn_code = _BTN_CODES[button]
+        self.mouse_move(x, y)
+        time.sleep(0.02)
+        self._client.pointer_button(btn_code, _PRESSED)
+
+    def mouse_button_up(self, x: int, y: int, button: MouseButton = MouseButton.LEFT) -> None:
+        """Move to coordinates and release a mouse button.
+
+        Args:
+            x, y: Coordinates.
+            button: Mouse button to release.
+        """
+        btn_code = _BTN_CODES[button]
+        self.mouse_move(x, y)
+        time.sleep(0.02)
+        self._client.pointer_button(btn_code, _RELEASED)
+
+    def keyboard_type(self, text: str) -> None:
+        """Type a string of text character by character."""
+        for char in text:
+            entry = _CHAR_KEY_MAP.get(char)
+            if entry is None:
+                continue
+
+            keycode, needs_shift = entry
+            if needs_shift:
+                self._client.keyboard_key(_MODIFIER_KEYS["shift"], _PRESSED)
+                time.sleep(0.01)
+
+            self._client.keyboard_key(keycode, _PRESSED)
+            time.sleep(0.01)
+            self._client.keyboard_key(keycode, _RELEASED)
+
+            if needs_shift:
+                time.sleep(0.01)
+                self._client.keyboard_key(_MODIFIER_KEYS["shift"], _RELEASED)
+
+            time.sleep(0.02)
+
+    def keyboard_key(self, key: str) -> None:
+        """Press a key combination (e.g., 'ctrl+c', 'Return', 'alt+F4').
+
+        Supports modifier combinations with '+' separator.
+        """
+        modifiers, keycode = _parse_key_combo(key)
+        if keycode is None:
+            return
+
+        # Press modifiers
+        for mod in modifiers:
+            self._client.keyboard_key(mod, _PRESSED)
+            time.sleep(0.01)
+
+        # Press and release main key
+        self._client.keyboard_key(keycode, _PRESSED)
+        time.sleep(0.01)
+        self._client.keyboard_key(keycode, _RELEASED)
+
+        # Release modifiers in reverse order
+        for mod in reversed(modifiers):
+            time.sleep(0.01)
+            self._client.keyboard_key(mod, _RELEASED)
+
+    def keyboard_key_down(self, key: str) -> None:
+        """Press (and hold) a key combination without releasing.
+
+        Useful for holding modifier keys across multiple actions.
+
+        Args:
+            key: Key to press (e.g., "ctrl", "shift+a", "alt").
+        """
+        modifiers, keycode = _parse_key_combo(key)
+
+        for mod in modifiers:
+            self._client.keyboard_key(mod, _PRESSED)
+            time.sleep(0.01)
+
+        if keycode is not None:
+            self._client.keyboard_key(keycode, _PRESSED)
+            time.sleep(0.01)
+
+    def keyboard_key_up(self, key: str) -> None:
+        """Release a previously pressed key combination.
+
+        Releases in reverse order (main key first, then modifiers).
+
+        Args:
+            key: Key to release (e.g., "ctrl", "shift+a", "alt").
+        """
+        modifiers, keycode = _parse_key_combo(key)
+
+        if keycode is not None:
+            self._client.keyboard_key(keycode, _RELEASED)
+            time.sleep(0.01)
+
+        for mod in reversed(modifiers):
+            self._client.keyboard_key(mod, _RELEASED)
+            time.sleep(0.01)
+
+    def touch_tap(self, x: int, y: int, hold_ms: int = 0) -> None:
+        """Tap at the given coordinates.
+
+        Args:
+            x, y: Coordinates to tap at.
+            hold_ms: Duration to hold before lifting (for long-press).
+        """
+        tid = self._client.touch_down(float(x), float(y))
+        if hold_ms > 0:
+            time.sleep(max(0.01, hold_ms / 1000.0))
+        else:
+            time.sleep(0.01)
+        self._client.touch_up(tid)
+
+    def touch_swipe(
+        self,
+        from_x: int,
+        from_y: int,
+        to_x: int,
+        to_y: int,
+        duration_ms: int = 300,
+    ) -> None:
+        """Swipe from one point to another.
+
+        Args:
+            from_x, from_y: Starting coordinates.
+            to_x, to_y: Ending coordinates.
+            duration_ms: Duration of the swipe in milliseconds.
+        """
+        steps = max(10, duration_ms // 10)
+        dx = to_x - from_x
+        dy = to_y - from_y
+
+        tid = self._client.touch_down(float(from_x), float(from_y))
+        step_delay = max(0.001, duration_ms / 1000.0 / steps)
+
+        for i in range(1, steps + 1):
+            frac = i / steps
+            cx = from_x + dx * frac
+            cy = from_y + dy * frac
+            self._client.touch_move(tid, cx, cy)
+            time.sleep(step_delay)
+
+        self._client.touch_up(tid)
+
+    def touch_pinch(
+        self,
+        center_x: int,
+        center_y: int,
+        start_distance: int,
+        end_distance: int,
+        duration_ms: int = 500,
+    ) -> None:
+        """Pinch gesture with two fingers.
+
+        Args:
+            center_x, center_y: Center point of the pinch.
+            start_distance: Initial distance between fingers (pixels).
+            end_distance: Final distance between fingers (pixels).
+            duration_ms: Duration of the gesture.
+        """
+        steps = max(10, duration_ms // 10)
+        step_delay = max(0.001, duration_ms / 1000.0 / steps)
+
+        # Two fingers start symmetrically on the x-axis
+        half_start = start_distance / 2.0
+        tid1 = self._client.touch_down(float(center_x - half_start), float(center_y))
+        tid2 = self._client.touch_down(float(center_x + half_start), float(center_y))
+
+        for i in range(1, steps + 1):
+            frac = i / steps
+            half = half_start + (end_distance / 2.0 - half_start) * frac
+            self._client.touch_move(tid1, float(center_x - half), float(center_y))
+            self._client.touch_move(tid2, float(center_x + half), float(center_y))
+            time.sleep(step_delay)
+
+        self._client.touch_up(tid1)
+        self._client.touch_up(tid2)
+
+    def touch_multi_swipe(
+        self,
+        from_x: int,
+        from_y: int,
+        to_x: int,
+        to_y: int,
+        fingers: int = 3,
+        duration_ms: int = 300,
+    ) -> None:
+        """Multi-finger swipe gesture.
+
+        Args:
+            from_x, from_y: Starting coordinates (center of finger group).
+            to_x, to_y: Ending coordinates.
+            fingers: Number of fingers (2-5).
+            duration_ms: Duration of the swipe.
+        """
+        steps = max(10, duration_ms // 10)
+        dx = to_x - from_x
+        dy = to_y - from_y
+        step_delay = max(0.001, duration_ms / 1000.0 / steps)
+        finger_spacing = 20  # pixels between fingers
+
+        # Start touches spread vertically around center
+        tids: list[int] = []
+        for f in range(fingers):
+            offset = (f - (fingers - 1) / 2.0) * finger_spacing
+            tid = self._client.touch_down(float(from_x), float(from_y + offset))
+            tids.append(tid)
+
+        for i in range(1, steps + 1):
+            frac = i / steps
+            cx = from_x + dx * frac
+            cy = from_y + dy * frac
+            for f, tid in enumerate(tids):
+                offset = (f - (fingers - 1) / 2.0) * finger_spacing
+                self._client.touch_move(tid, cx, cy + offset)
+            time.sleep(step_delay)
+
+        for tid in tids:
+            self._client.touch_up(tid)
+
+    def keyboard_type_unicode(self, text: str, dbus_address: str | None = None) -> bool:
+        """Type arbitrary Unicode text using wtype or clipboard fallback.
+
+        Args:
+            text: Text to type (supports non-ASCII, e.g. Korean, CJK).
+            dbus_address: D-Bus address for the session (needed for wl-copy fallback).
+
+        Returns:
+            True if text was typed successfully.
+        """
+        env = dict(__import__("os").environ)
+        if dbus_address:
+            env["DBUS_SESSION_BUS_ADDRESS"] = dbus_address
+
+        # Try wtype first
+        if shutil.which("wtype"):
+            result = subprocess.run(
+                ["wtype", "--", text],
+                env=env,
+                capture_output=True,
+                timeout=5,
+            )
+            return result.returncode == 0
+
+        # Fallback: clipboard paste via wl-copy + Ctrl+V
+        # Use Popen + DEVNULL to avoid pipe-blocking from wl-copy's forked child
+        if shutil.which("wl-copy"):
+            cp = subprocess.Popen(
+                ["wl-copy", "--", text],
+                env=env,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            time.sleep(0.1)  # Wait for fork to complete
+            if cp.poll() is None or cp.returncode == 0:
+                self.keyboard_key("ctrl+v")
+                return True
+
+        return False
+
+    def close(self) -> None:
+        """Close the EIS connection."""
+        self._client.close()
+
+
+def _key_name_to_evdev(name: str) -> int | None:
+    """Convert a key name to its Linux evdev keycode."""
+    lower = name.lower()
+
+    if lower in _EVDEV_KEY_MAP:
+        return _EVDEV_KEY_MAP[lower]
+
+    # Single character → look up in character map
+    if len(name) == 1:
+        entry = _CHAR_KEY_MAP.get(name)
+        if entry:
+            return entry[0]
+
+    return None
+
+
+def _resolve_modifiers(modifiers: list[str] | None) -> list[int]:
+    """Resolve modifier key names to evdev keycodes."""
+    if not modifiers:
+        return []
+    codes: list[int] = []
+    for mod in modifiers:
+        code = _MODIFIER_KEYS.get(mod.lower())
+        if code is not None:
+            codes.append(code)
+    return codes
+
+
+def _parse_key_combo(key: str) -> tuple[list[int], int | None]:
+    """Parse a key combo string into (modifier_codes, main_keycode).
+
+    Returns a tuple of (list of modifier evdev keycodes, main key evdev keycode or None).
+    """
+    parts = key.split("+")
+    modifiers: list[int] = []
+    main_key: str | None = None
+
+    for part in parts:
+        part_lower = part.strip().lower()
+        if part_lower in _MODIFIER_KEYS:
+            modifiers.append(_MODIFIER_KEYS[part_lower])
+        else:
+            main_key = part.strip()
+
+    keycode: int | None = None
+    if main_key is not None:
+        keycode = _key_name_to_evdev(main_key)
+
+    return modifiers, keycode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Text injection into isolated virtual sessions produced the host keyboard layout's characters (e.g. `hello` → `руддщ` on a host with `ru,us` layouts): `kwin_wayland --virtual` inherited the host's `XDG_CONFIG_HOME` and compiled its `kxkbrc` layout list into the keymap. Virtual sessions now run with a throwaway per-session config dir (pre-seeded to disable the kwallet popup that stole compositor focus at startup) and without the host's `XKB_DEFAULT_*` environment variables, so the EIS keyboard types plain US ASCII regardless of host layout configuration
 - Segfault on Python 3.14 caused by missing `argtypes` on variadic `ei_seat_bind_capabilities` ctypes call
 
 ## [0.7.0] - 2026-03-29

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ requires = ["uv_build>=0.10.3,<0.12.0"]
 build-backend = "uv_build"
 
 [dependency-groups]
-dev = ["ruff>=0.11.0", "ty>=0.0.1"]
+dev = ["ruff>=0.11.0", "ty>=0.0.1", "pytest>=9.0.1"]
 
 [tool.ruff]
 target-version = "py312"

--- a/src/kwin_mcp/session.py
+++ b/src/kwin_mcp/session.py
@@ -40,6 +40,29 @@ class SessionConfig:
     extra_env: dict[str, str] = field(default_factory=dict)
 
 
+def _write_deterministic_session_config(config_dir: Path) -> None:
+    """Pre-seed an isolated config dir with settings that make sessions deterministic.
+
+    KWin builds its XKB keymap from ``$XDG_CONFIG_HOME/kxkbrc`` and falls back
+    to the environment (``XKB_DEFAULT_LAYOUT``), which on hosts configured with
+    a non-US primary layout (e.g. ``ru,us``) makes evdev keycodes typed by the
+    EIS keyboard produce the wrong characters (``hello`` → ``руддщ``).
+    Leaving ``kxkbrc`` absent from the isolated config dir keeps the default
+    US layout.
+
+    The same directory silences the kwallet popup (ksecretd/kwalletd) that
+    steals compositor focus at session start, which otherwise breaks
+    focus-dependent automation flows such as ``focus_window`` + keyboard
+    verification.
+
+    Only writes files that do not exist yet so explicit pre-seeding wins.
+    """
+    config_dir.mkdir(parents=True, exist_ok=True)
+    kwalletrc = config_dir / "kwalletrc"
+    if not kwalletrc.exists():
+        kwalletrc.write_text("[Wallet]\nEnabled=false\nFirst Use=false\nLaunch Manager=false\n")
+
+
 @dataclass
 class AppInfo:
     """Tracking info for a launched application."""
@@ -80,6 +103,7 @@ class Session:
         self._app_counter: int = 0
         self._config: SessionConfig | None = None
         self._home_dir: Path | None = None
+        self._session_config_dir: Path | None = None
 
     @property
     def is_running(self) -> bool:
@@ -140,6 +164,18 @@ class Session:
         for suffix in ("", ".lock"):
             path = Path(runtime_dir) / f"{self._socket_name}{suffix}"
             path.unlink(missing_ok=True)
+
+        # Deterministic per-session config dir: without an isolated
+        # XDG_CONFIG_HOME, KWin inherits the host's kxkbrc and the virtual
+        # session runs with the host's XKB layout list (e.g. ru,us — the
+        # evdev keycodes then type Cyrillic instead of ASCII), and the
+        # kwallet popup steals focus at session start.
+        self._session_config_dir = Path(tempfile.mkdtemp(prefix="kwin-mcp-config-"))
+        _write_deterministic_session_config(self._session_config_dir)
+        # Deliberately NOT isolating XDG_DATA_HOME / XDG_CACHE_HOME: qtbase
+        # crash-logs a fatal qFatal when a nonexistent standard data dir is
+        # set (reproduced on qt6-base 6.10), and existing dirs already
+        # contain everything kwin/konsole need to start.
 
         # Build the wrapper script that runs inside dbus-run-session
         wrapper_script = self._build_wrapper_script(config)
@@ -324,6 +360,11 @@ class Session:
             path = Path(runtime_dir) / f"{self._socket_name}{suffix}"
             path.unlink(missing_ok=True)
 
+        # Remove the per-session config dir
+        if self._session_config_dir is not None:
+            shutil.rmtree(self._session_config_dir, ignore_errors=True)
+            self._session_config_dir = None
+
         self._process = None
         self._info = None
         self._home_dir = None
@@ -399,6 +440,23 @@ wait $KWIN_PID
             # Safe in isolated virtual sessions where there is no user desktop to protect.
             "KWIN_WAYLAND_NO_PERMISSION_CHECKS": "1",
         }
+        # Per-session deterministic config dir (US keymap via absent kxkbrc,
+        # kwallet popup disabled). Set after os.environ so it always wins.
+        if self._session_config_dir is not None:
+            env["XDG_CONFIG_HOME"] = str(self._session_config_dir)
+            # Strip host XKB defaults: on hosts with a non-US primary layout
+            # (e.g. ru,us via locale1) KWin compiles that keymap even with an
+            # empty kxkbrc, and evdev keycodes from the EIS keyboard then
+            # produce the host layout's characters instead of ASCII.
+            # An empty XKB_DEFAULT_LAYOUT resets libxkbcommon to plain "us".
+            for var in (
+                "XKB_DEFAULT_LAYOUT",
+                "XKB_DEFAULT_VARIANT",
+                "XKB_DEFAULT_OPTIONS",
+                "XKB_DEFAULT_RULES",
+                "XKB_DEFAULT_MODEL",
+            ):
+                env.pop(var, None)
         # Remove host display references to avoid kwin connecting to host
         env.pop("WAYLAND_DISPLAY", None)
         env.pop("DISPLAY", None)

--- a/tests/test_session_keymap.py
+++ b/tests/test_session_keymap.py
@@ -1,0 +1,84 @@
+"""Tests for per-session XDG_CONFIG_HOME isolation and XKB default stripping.
+
+``kwin_wayland --virtual`` inherits the host's XDG config directory: KWin
+compiles the host's ``kxkbrc`` layout list (e.g. ``LayoutList=ru,us``) into
+its keymap — or falls back to the ``XKB_DEFAULT_*`` environment variables —
+so evdev keycodes injected through the EIS keyboard produce the host layout's
+characters (``hello`` → ``руддщ``) instead of ASCII. The kwallet popup
+(ksecretd/kwalletd) also steals compositor focus at session start.
+
+``Session`` now creates a throwaway config dir pre-seeded with ``kwalletrc``
+(wallet disabled), points ``XDG_CONFIG_HOME`` at it, and strips the host
+``XKB_DEFAULT_*`` variables so libxkbcommon resets to the plain ``us`` layout.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from kwin_mcp.session import Session, SessionConfig, _write_deterministic_session_config
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_XKB_VARS = (
+    "XKB_DEFAULT_LAYOUT",
+    "XKB_DEFAULT_VARIANT",
+    "XKB_DEFAULT_OPTIONS",
+    "XKB_DEFAULT_RULES",
+    "XKB_DEFAULT_MODEL",
+)
+
+
+def test_deterministic_config_disables_kwallet(tmp_path: Path) -> None:
+    """The pre-seeded kwalletrc disables the wallet manager popup."""
+    config_dir = tmp_path / "config"
+    _write_deterministic_session_config(config_dir)
+    content = (config_dir / "kwalletrc").read_text()
+    assert "[Wallet]" in content
+    assert "Enabled=false" in content
+
+
+def test_deterministic_config_does_not_overwrite_existing(tmp_path: Path) -> None:
+    """Explicit pre-seeding wins: an existing kwalletrc is left untouched."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "kwalletrc").write_text("[Wallet]\nEnabled=true\n")
+
+    _write_deterministic_session_config(config_dir)
+
+    assert (config_dir / "kwalletrc").read_text() == "[Wallet]\nEnabled=true\n"
+
+
+def test_build_env_points_config_home_at_session_dir(tmp_path: Path, monkeypatch) -> None:
+    """_build_env overrides XDG_CONFIG_HOME with the per-session config dir."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", "/host/config")
+
+    session = Session()
+    session._session_config_dir = tmp_path
+    env = session._build_env(SessionConfig())
+
+    assert env["XDG_CONFIG_HOME"] == str(tmp_path)
+
+
+def test_build_env_strips_host_xkb_defaults(tmp_path: Path, monkeypatch) -> None:
+    """Host XKB_DEFAULT_* variables must not reach the compositor."""
+    for var in _XKB_VARS:
+        monkeypatch.setenv(var, "ru,us")
+
+    session = Session()
+    session._session_config_dir = tmp_path
+    env = session._build_env(SessionConfig())
+
+    for var in _XKB_VARS:
+        assert var not in env
+
+
+def test_build_env_without_session_dir_keeps_host_config(monkeypatch) -> None:
+    """Without a session config dir (e.g. before start()) nothing is injected."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", "/host/config")
+
+    session = Session()
+    env = session._build_env(SessionConfig())
+
+    assert env["XDG_CONFIG_HOME"] == "/host/config"

--- a/uv.lock
+++ b/uv.lock
@@ -235,6 +235,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -274,6 +283,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -288,6 +298,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pytest", specifier = ">=9.0.1" },
     { name = "ruff", specifier = ">=0.11.0" },
     { name = "ty", specifier = ">=0.0.1" },
 ]
@@ -315,6 +326,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
 ]
 
 [[package]]
@@ -384,6 +404,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/01/4a/9202e8d11714c1fc5951f2e1ef362f2d7fbc595e1f6717971d5dd750e969/pillow-12.1.1-cp314-cp314t-win32.whl", hash = "sha256:d2912fd8114fc5545aa3a4b5576512f64c55a03f3ebcca4c10194d593d43ea36", size = 6438736, upload-time = "2026-02-11T04:22:46.347Z" },
     { url = "https://files.pythonhosted.org/packages/f3/ca/cbce2327eb9885476b3957b2e82eb12c866a8b16ad77392864ad601022ce/pillow-12.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:4ceb838d4bd9dab43e06c363cab2eebf63846d6a4aeaea283bbdfd8f1a8ed58b", size = 7182894, upload-time = "2026-02-11T04:22:48.114Z" },
     { url = "https://files.pythonhosted.org/packages/ec/d2/de599c95ba0a973b94410477f8bf0b6f0b5e67360eb89bcb1ad365258beb/pillow-12.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:7b03048319bfc6170e93bd60728a1af51d3dd7704935feb228c4d4faab35d334", size = 2546446, upload-time = "2026-02-11T04:22:50.342Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -515,6 +544,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
 name = "pygobject"
 version = "3.54.5"
 source = { registry = "https://pypi.org/simple" }
@@ -535,6 +573,22 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

`kwin_wayland --virtual` inherits the **host** keyboard configuration: with `LayoutList=ru,us` in the host `kxkbrc`, bare evdev keycodes sent via EIS are interpreted against the host keymap — text arrives as Cyrillic instead of Latin. Verified experimentally: typing `hello` via `keyboard_type` produced `руддщ` in the focused application. Modifier combos are unaffected (they don't depend on the letters level), which masked this for a while.

A kwallet popup from the inherited config also steals focus during session start.

## Fix

Per-session `XDG_CONFIG_HOME` (a tmp dir containing only `kwalletrc` with `Enabled=false`) and `XKB_DEFAULT_*` stripped from the compositor environment. Verified via the EIS keymap fd: before — `Russian+English`, after — `US-only` (`AD01` → `0x71`).

## Testing

- New `tests/test_session_keymap.py` (5 tests) — env construction only, no real sessions; adds `pytest` to the dev group (runs locally; happy to adapt to the pytest infra from #20/#42).
- Full local verification: `ruff check`, `ruff format --check`, `ty check`, `uv build`, `pytest` — green.
- Validated end-to-end in the maintained fork (30/30 tool integration runs; text delivery 5/5 file-artifact tests after this change).

Related context: text-delivery follow-up (clipboard paste path) is in a sibling PR; this one fixes the root cause for `keyboard_type`/`keyboard_key` alone.