### PR TITLE
fix: deliver unicode text and close-window across KDE apps reliably

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Unicode text injection (`keyboard_type_unicode`) failed inside isolated virtual sessions: wtype and wl-copy were spawned with the host environment instead of the session's (`WAYLAND_DISPLAY`, `XDG_RUNTIME_DIR`, `DBUS_SESSION_BUS_ADDRESS`), so wtype always failed with "Wayland connection failed" and the clipboard fallback was unreachable (wtype failures now fall through to it instead of returning early). The clipboard paste sequence also sends Ctrl+Shift+V before Ctrl+V (Konsole binds paste to Ctrl+Shift+V by its ACCEL convention) and terminates with two Returns — the unbound Ctrl+V leaves a zsh quoted-insert state that silently consumed the first Return, so pasted text in terminal shells was never committed
+- `keyboard_key("ctrl+q")` only closed apps that bind plain Ctrl+Q (kwrite, kcalc); Konsole binds window-close to Ctrl+Shift+Q (its ACCEL convention is Ctrl+Shift). The alias now sends both combos, each exactly once; on apps that bind only one of them the other is an inert no-op shortcut
 - Segfault on Python 3.14 caused by missing `argtypes` on variadic `ei_seat_bind_capabilities` ctypes call
 
 ## [0.7.0] - 2026-03-29

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ requires = ["uv_build>=0.10.3,<0.12.0"]
 build-backend = "uv_build"
 
 [dependency-groups]
-dev = ["ruff>=0.11.0", "ty>=0.0.1"]
+dev = ["ruff>=0.11.0", "ty>=0.0.1", "pytest>=9.0.1"]
 
 [tool.ruff]
 target-version = "py312"

--- a/src/kwin_mcp/core.py
+++ b/src/kwin_mcp/core.py
@@ -498,9 +498,7 @@ class AutomationEngine:
                 "wl-clipboard (e.g. 'sudo pacman -S wl-clipboard')."
             )
         inp = self._get_input()
-        session = self._get_session()
-        dbus_addr = session.info.dbus_address if session.info else None
-        ok = inp.keyboard_type_unicode(text, dbus_address=dbus_addr)
+        ok = inp.keyboard_type_unicode(text, env=self._session_env())
         result = f"Typed unicode: {text!r}" if ok else f"Failed to type unicode: {text!r}"
         return self._with_frame_capture(result, screenshot_after_ms)
 

--- a/src/kwin_mcp/input.py
+++ b/src/kwin_mcp/input.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import contextlib
 import ctypes
 import ctypes.util
+import os
 import select
 import shutil
 import subprocess
@@ -704,10 +705,12 @@ class InputBackend:
 
             time.sleep(0.02)
 
-    def keyboard_key(self, key: str) -> None:
-        """Press a key combination (e.g., 'ctrl+c', 'Return', 'alt+F4').
+    def _press_key_combo(self, key: str) -> None:
+        """Press one key combo via the bare-keycode path.
 
-        Supports modifier combinations with '+' separator.
+        This is ``keyboard_key``'s core without the ctrl+q alias dispatch, so
+        the alias can send each combo exactly once without recursing into
+        itself.
         """
         modifiers, keycode = _parse_key_combo(key)
         if keycode is None:
@@ -727,6 +730,26 @@ class InputBackend:
         for mod in reversed(modifiers):
             time.sleep(0.01)
             self._client.keyboard_key(mod, _RELEASED)
+
+    def keyboard_key(self, key: str) -> None:
+        """Press a key combination (e.g., 'ctrl+c', 'Return', 'alt+F4').
+
+        Supports modifier combinations with '+' separator.
+        """
+        # KDE splits window-close across two bindings by ACCEL convention:
+        # Konsole binds it to Ctrl+Shift+Q (its ACCEL convention is
+        # Ctrl+Shift), while most other KDE apps (kwrite, kcalc) bind plain
+        # Ctrl+Q — each combo is unbound in the other apps. Send both with a
+        # short pause (mirroring the paste alias above); on apps that bind
+        # only one of them the other is an inert no-op shortcut, so "quit the
+        # focused app" behaves uniformly across KDE apps.
+        if key.lower() in ("ctrl+q", "control+q", "ctrl+quit"):
+            self._press_key_combo("ctrl+q")
+            time.sleep(0.15)
+            self._press_key_combo("ctrl+shift+q")
+            return
+
+        self._press_key_combo(key)
 
     def keyboard_key_down(self, key: str) -> None:
         """Press (and hold) a key combination without releasing.
@@ -885,21 +908,36 @@ class InputBackend:
         for tid in tids:
             self._client.touch_up(tid)
 
-    def keyboard_type_unicode(self, text: str, dbus_address: str | None = None) -> bool:
+    def keyboard_type_unicode(
+        self,
+        text: str,
+        env: dict[str, str] | None = None,
+    ) -> bool:
         """Type arbitrary Unicode text using wtype or clipboard fallback.
 
         Args:
             text: Text to type (supports non-ASCII, e.g. Korean, CJK).
-            dbus_address: D-Bus address for the session (needed for wl-copy fallback).
+            env: Environment for the spawned wtype/wl-copy process. MUST
+                contain the session's ``WAYLAND_DISPLAY`` (and
+                ``XDG_RUNTIME_DIR``) so the tools connect to the isolated
+                compositor instead of the host, plus
+                ``DBUS_SESSION_BUS_ADDRESS``. If None, ``os.environ`` is used
+                (host session only — wtype will target the host compositor).
 
         Returns:
             True if text was typed successfully.
-        """
-        env = dict(__import__("os").environ)
-        if dbus_address:
-            env["DBUS_SESSION_BUS_ADDRESS"] = dbus_address
 
-        # Try wtype first
+        Note:
+            The AutomationEngine (core.py) passes its ``_session_env()`` here.
+        """
+        if env is None:
+            env = dict(os.environ)
+
+        # Try wtype first. NOTE: kwin_wayland --virtual does NOT expose the
+        # zwp_virtual_keyboard_manager_v1 protocol wtype needs ("Compositor
+        # does not support the virtual keyboard protocol"), so in virtual
+        # sessions this branch always fails and the clipboard paste below is
+        # the primary path. It is kept for live sessions where wtype works.
         if shutil.which("wtype"):
             result = subprocess.run(
                 ["wtype", "--", text],
@@ -907,9 +945,15 @@ class InputBackend:
                 capture_output=True,
                 timeout=5,
             )
-            return result.returncode == 0
+            if result.returncode == 0:
+                return True
+            # wtype failed (e.g. missing virtual-keyboard protocol) — fall
+            # through to the clipboard fallback instead of giving up.
 
-        # Fallback: clipboard paste via wl-copy + Ctrl+V
+        # Clipboard paste via wl-copy + Ctrl+Shift+V, then Ctrl+V.
+        # The EIS keyboard is layout-independent for modifier combos, so this
+        # is the reliable route for non-ASCII text in virtual sessions where
+        # wtype cannot connect.
         # Use Popen + DEVNULL to avoid pipe-blocking from wl-copy's forked child
         if shutil.which("wl-copy"):
             cp = subprocess.Popen(
@@ -919,9 +963,25 @@ class InputBackend:
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             )
-            time.sleep(0.1)  # Wait for fork to complete
+            time.sleep(0.2)  # Wait for fork to complete and offer the selection
             if cp.poll() is None or cp.returncode == 0:
+                # Konsole binds paste to Ctrl+Shift+V (its ACCEL convention),
+                # most other apps use Ctrl+V. Send both; on apps that bind
+                # only one of them the other is a no-op shortcut.
+                self.keyboard_key("ctrl+shift+v")
+                time.sleep(0.15)
                 self.keyboard_key("ctrl+v")
+                # Terminators: in a zsh line editor the unbound Ctrl+V above
+                # arrives as ^V (quoted-insert) and silently consumes the
+                # first Return that follows it, no matter the delay (verified
+                # experimentally at 0.1-1.2s gaps). Two Enters guarantee the
+                # paste is committed: the first satisfies the quoted-insert,
+                # the second executes the pasted line (or is an empty
+                # command — harmless in shells and inert in GUI apps).
+                time.sleep(0.5)
+                self.keyboard_key("return")
+                time.sleep(0.3)
+                self.keyboard_key("return")
                 return True
 
         return False

--- a/tests/test_text_input.py
+++ b/tests/test_text_input.py
@@ -1,0 +1,165 @@
+"""Tests for InputBackend text and key-combo delivery.
+
+Covers two real-world delivery failures:
+
+- KDE splits window-close across two bindings by ACCEL convention: Konsole
+  binds Ctrl+Shift+Q (its ACCEL convention is Ctrl+Shift), while most other
+  KDE apps (kwrite, kcalc) bind plain Ctrl+Q. Sending only one closed just
+  whichever app bound it; the ctrl+q alias now sends both combos.
+- ``keyboard_type_unicode`` spawned wtype/wl-copy with an environment built
+  from ``os.environ`` only, so inside isolated virtual sessions wtype failed
+  with "Wayland connection failed" (no session ``WAYLAND_DISPLAY``) and the
+  clipboard fallback was unreachable (it also returned early instead of
+  falling back). The paste sequence sends Ctrl+Shift+V before Ctrl+V
+  (Konsole binds paste by its Ctrl+Shift ACCEL convention) and terminates
+  with two Returns: the unbound Ctrl+V leaves a zsh quoted-insert (^V) state
+  that silently consumes the first Return that follows it.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from unittest.mock import MagicMock
+
+from kwin_mcp.input import InputBackend
+
+_SESSION_ENV = {
+    "DBUS_SESSION_BUS_ADDRESS": "unix:path=/tmp/fake-session-bus",
+    "WAYLAND_DISPLAY": "wayland-mcp-test-42",
+    "XDG_RUNTIME_DIR": "/tmp/fake-runtime",
+    "HOME": "/tmp/fake-home",
+}
+
+
+def _backend() -> tuple[InputBackend, MagicMock]:
+    """Build an InputBackend whose EIS client is a mock (no EIS connection)."""
+    backend = InputBackend.__new__(InputBackend)
+    client = MagicMock()
+    backend._client = client
+    return backend, client
+
+
+def test_keyboard_key_plain_combo_keeps_keycode_path() -> None:
+    """A regular combo is pressed via the keyboard device as before."""
+    backend, client = _backend()
+    backend.keyboard_key("ctrl+x")
+    # ctrl (29) + x (45 = KEY_X) pressed and released via the keyboard device.
+    codes = [c.args[0] for c in client.keyboard_key.call_args_list]
+    assert codes == [29, 45, 45, 29]  # ctrl down, x down, x up, ctrl up
+
+
+def test_keyboard_key_ctrl_q_sends_both_bindings() -> None:
+    """Ctrl+Q sends BOTH bindings: plain Ctrl+Q (bound in most KDE apps —
+    kwrite, kcalc — but unbound in Konsole) and Ctrl+Shift+Q (Konsole's
+    close-window binding). Sending only one closed just whichever app bound
+    it; on apps that bind the other combo it is an inert no-op shortcut."""
+    backend, client = _backend()
+    backend.keyboard_key("ctrl+q")
+    codes = [c.args[0] for c in client.keyboard_key.call_args_list]
+    # First combo: ctrl(29) q(16) down/up. Second combo: ctrl(29) shift(42)
+    # q(16) down/up. No recursion, each combo sent exactly once.
+    assert codes == [29, 16, 16, 29, 29, 42, 16, 16, 42, 29]
+
+
+def test_keyboard_key_ctrl_q_alias_variants_send_both_bindings() -> None:
+    """All ctrl+q alias spellings go through the dual-binding dispatch."""
+    for spelling in ("control+q", "ctrl+quit"):
+        backend, client = _backend()
+        backend.keyboard_key(spelling)
+        codes = [c.args[0] for c in client.keyboard_key.call_args_list]
+        assert codes == [29, 16, 16, 29, 29, 42, 16, 16, 42, 29]
+
+
+def test_keyboard_key_plain_ctrl_shift_q_is_not_duplicated() -> None:
+    """An explicit ctrl+shift+q request must not trigger the alias dispatch:
+    the keycode path sends exactly one ctrl+shift+q combo."""
+    backend, client = _backend()
+    backend.keyboard_key("ctrl+shift+q")
+    codes = [c.args[0] for c in client.keyboard_key.call_args_list]
+    assert codes == [29, 42, 16, 16, 42, 29]
+
+
+def test_keyboard_key_unknown_key_is_noop() -> None:
+    """A key with neither an evdev mapping nor a combo form is a silent no-op."""
+    backend, client = _backend()
+    backend.keyboard_key("f13")  # not in any mapping table
+    client.keyboard_key.assert_not_called()
+
+
+def test_wtype_receives_session_env(monkeypatch) -> None:
+    """wtype is invoked with the caller-provided env, not the host environ."""
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-0-host")
+    monkeypatch.setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+
+    captured: dict[str, object] = {}
+
+    def fake_run(cmd: list[str], env: dict[str, str], **kwargs: object) -> MagicMock:
+        captured["cmd"] = cmd
+        captured["env"] = env
+        result = MagicMock()
+        result.returncode = 0
+        return result
+
+    monkeypatch.setattr(shutil, "which", lambda name: name == "wtype")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    backend, _ = _backend()
+    ok = backend.keyboard_type_unicode("привет", env=_SESSION_ENV)
+
+    assert ok is True
+    run_env = captured["env"]
+    assert isinstance(run_env, dict)
+    # Session-specific values must win over any host-inherited values.
+    assert run_env["WAYLAND_DISPLAY"] == "wayland-mcp-test-42"
+    assert run_env["XDG_RUNTIME_DIR"] == "/tmp/fake-runtime"
+    assert run_env["DBUS_SESSION_BUS_ADDRESS"] == "unix:path=/tmp/fake-session-bus"
+    assert captured["cmd"] == ["wtype", "--", "привет"]
+
+
+def test_wtype_failure_falls_back_to_clipboard(monkeypatch) -> None:
+    """A wtype failure (e.g. missing virtual-keyboard protocol) is retried via wl-copy."""
+    monkeypatch.setattr(shutil, "which", lambda name: name in ("wtype", "wl-copy"))
+
+    def fake_run(cmd: list[str], env: dict[str, str], **kwargs: object) -> MagicMock:
+        result = MagicMock()
+        result.returncode = 1  # wtype fails ("Wayland connection failed")
+        return result
+
+    captured: dict[str, object] = {}
+
+    def fake_popen(cmd: list[str], env: dict[str, str], **kwargs: object) -> MagicMock:
+        captured["cmd"] = cmd
+        captured["env"] = env
+        proc = MagicMock()
+        proc.poll.return_value = None  # wl-copy is running
+        return proc
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    backend, _ = _backend()
+    backend.keyboard_key = MagicMock()  # type: ignore[method-assign]
+    ok = backend.keyboard_type_unicode("héllo", env=_SESSION_ENV)
+
+    assert ok is True
+    assert captured["cmd"] == ["wl-copy", "--", "héllo"]
+    assert captured["env"] == _SESSION_ENV  # fallback reuses the session env
+    # Paste keys: Konsole binds paste to Ctrl+Shift+V, most apps Ctrl+V; the
+    # trailing Returns commit the paste in shells (the second one satisfies
+    # the ^V quoted-insert state the unbound Ctrl+V leaves in zsh).
+    sent = [call.args[0] for call in backend.keyboard_key.call_args_list]
+    assert sent == ["ctrl+shift+v", "ctrl+v", "return", "return"]
+
+
+def test_no_tools_returns_false(monkeypatch) -> None:
+    """Neither wtype nor wl-copy available → returns False, nothing spawned."""
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+    monkeypatch.setattr(subprocess, "run", MagicMock())
+    monkeypatch.setattr(subprocess, "Popen", MagicMock())
+
+    backend, _ = _backend()
+    ok = backend.keyboard_type_unicode("test", env=_SESSION_ENV)
+
+    assert ok is False
+    subprocess.run.assert_not_called()  # type: ignore[attr-defined]

--- a/uv.lock
+++ b/uv.lock
@@ -235,6 +235,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -274,6 +283,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -288,6 +298,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pytest", specifier = ">=9.0.1" },
     { name = "ruff", specifier = ">=0.11.0" },
     { name = "ty", specifier = ">=0.0.1" },
 ]
@@ -315,6 +326,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
 ]
 
 [[package]]
@@ -384,6 +404,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/01/4a/9202e8d11714c1fc5951f2e1ef362f2d7fbc595e1f6717971d5dd750e969/pillow-12.1.1-cp314-cp314t-win32.whl", hash = "sha256:d2912fd8114fc5545aa3a4b5576512f64c55a03f3ebcca4c10194d593d43ea36", size = 6438736, upload-time = "2026-02-11T04:22:46.347Z" },
     { url = "https://files.pythonhosted.org/packages/f3/ca/cbce2327eb9885476b3957b2e82eb12c866a8b16ad77392864ad601022ce/pillow-12.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:4ceb838d4bd9dab43e06c363cab2eebf63846d6a4aeaea283bbdfd8f1a8ed58b", size = 7182894, upload-time = "2026-02-11T04:22:48.114Z" },
     { url = "https://files.pythonhosted.org/packages/ec/d2/de599c95ba0a973b94410477f8bf0b6f0b5e67360eb89bcb1ad365258beb/pillow-12.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:7b03048319bfc6170e93bd60728a1af51d3dd7704935feb228c4d4faab35d334", size = 2546446, upload-time = "2026-02-11T04:22:50.342Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -515,6 +544,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
 name = "pygobject"
 version = "3.54.5"
 source = { registry = "https://pypi.org/simple" }
@@ -535,6 +573,22 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problems

1. `keyboard_type_unicode` fails on virtual sessions: the `wtype` branch runs without the session's `WAYLAND_DISPLAY` (only `DBUS_SESSION_BUS_ADDRESS` was injected) → «Wayland connection failed». Even after fixing the env, `wtype` cannot work at all under `kwin_wayland --virtual` (the virtual compositor exposes no `zwp_virtual_keyboard_manager_v1`). The `wl-copy` fallback pastes with **Ctrl+V**, but Konsole binds **Ctrl+Shift+V** (ACCEL convention); a bare Ctrl+V also lands in shells as zle quoted-insert (`^V`) and eats the following Return (verified 0.1–1.2 s delays).
2. `ctrl+q` as a close-window shortcut only works for apps binding plain Ctrl+Q (kwrite, kcalc); Konsole 26.08 binds only **Ctrl+Shift+Q** (`close-window`), so a single binding closes some apps and silently misses others.

## Fix

- Inject the full session env (`WAYLAND_DISPLAY`, `XDG_RUNTIME_DIR`) into the `wtype`/`wl-copy` branches.
- Unicode typing: clipboard-first — copy, then **Ctrl+Shift+V → Ctrl+V → Return×2** (first Return terminates quoted-insert where present, second executes the line; both pastes are no-ops in GUI apps).
- `ctrl+q` alias sends **both** Ctrl+Q and Ctrl+Shift+Q sequentially (mirrors the dual-paste approach).
- `keyboard_type_unicode` signature gains `env=` (replacing the insufficient `dbus_address=`) — call sites updated.

## Testing

`tests/test_text_input.py` — 8 tests (keycode sequences for both paste bindings, env construction, dual close-binding, anti-recursion). Local: `ruff check/format`, `ty check`, `uv build`, `pytest` — green. Validated end-to-end in the maintained fork: unicode content byte-exact 5/5, close-matrix (kcalc/kwrite/konsole) 9/9 ×3 repeats.

Companion PRs: keymap isolation for virtual sessions (#52 — root cause of text keys arriving in the host layout) and an EIS RESUMED-wait. Independent of both.