### PR TITLE
fix: load libei lazily so the package imports without it installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Importing `kwin_mcp` failed on systems without libei installed even when no EIS input functionality was used: the shared library was loaded eagerly at import time. It is now loaded lazily on first use, so linting, type-checking and packaging environments work without the native library
 - Segfault on Python 3.14 caused by missing `argtypes` on variadic `ei_seat_bind_capabilities` ctypes call
 
 ## [0.7.0] - 2026-03-29

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ requires = ["uv_build>=0.10.3,<0.12.0"]
 build-backend = "uv_build"
 
 [dependency-groups]
-dev = ["ruff>=0.11.0", "ty>=0.0.1"]
+dev = ["ruff>=0.11.0", "ty>=0.0.1", "pytest>=9.0.1"]
 
 [tool.ruff]
 target-version = "py312"

--- a/src/kwin_mcp/input.py
+++ b/src/kwin_mcp/input.py
@@ -218,8 +218,19 @@ def _load_libei() -> ctypes.CDLL:
     return lib
 
 
-# Module-level libei instance (loaded once)
-_libei = _load_libei()
+# Module-level libei instance, loaded lazily on first use. Loading eagerly at
+# import time makes importing this module fail on systems without libei
+# installed (e.g. CI jobs that only lint or type-check), even though no EIS
+# input path is touched there.
+_libei: ctypes.CDLL | None = None
+
+
+def _get_libei() -> ctypes.CDLL:
+    """Return the process-wide libei handle, loading it on first call."""
+    global _libei
+    if _libei is None:
+        _libei = _load_libei()
+    return _libei
 
 
 class EISClient:
@@ -262,16 +273,16 @@ class EISClient:
         self._cookie = int(result[1])
 
         # Create libei sender context
-        self._ei = _libei.ei_new_sender(None)
+        self._ei = _get_libei().ei_new_sender(None)
         if not self._ei:
             msg = "Failed to create EI context"
             raise RuntimeError(msg)
 
-        _libei.ei_configure_name(self._ei, b"kwin-mcp")
+        _get_libei().ei_configure_name(self._ei, b"kwin-mcp")
 
-        ret = _libei.ei_setup_backend_fd(self._ei, fd)
+        ret = _get_libei().ei_setup_backend_fd(self._ei, fd)
         if ret != 0:
-            _libei.ei_unref(self._ei)
+            _get_libei().ei_unref(self._ei)
             self._ei = 0
             msg = f"ei_setup_backend_fd failed: {ret}"
             raise RuntimeError(msg)
@@ -281,25 +292,25 @@ class EISClient:
 
     def _negotiate_devices(self, timeout: float = 5.0) -> None:
         """Process EIS handshake events until we have pointer + keyboard."""
-        ei_fd = _libei.ei_get_fd(self._ei)
+        ei_fd = _get_libei().ei_get_fd(self._ei)
         start = time.monotonic()
 
         while time.monotonic() - start < timeout:
             readable, _, _ = select.select([ei_fd], [], [], 0.3)
             if readable:
-                ret = _libei.ei_dispatch(self._ei)
+                ret = _get_libei().ei_dispatch(self._ei)
                 if ret < 0:
                     break
 
             while True:
-                event = _libei.ei_get_event(self._ei)
+                event = _get_libei().ei_get_event(self._ei)
                 if not event:
                     break
 
-                etype = _libei.ei_event_get_type(event)
+                etype = _get_libei().ei_event_get_type(event)
 
                 if etype == _EI_EVENT_DISCONNECT:
-                    _libei.ei_event_unref(event)
+                    _get_libei().ei_event_unref(event)
                     msg = "EIS server disconnected during handshake"
                     raise RuntimeError(msg)
 
@@ -312,7 +323,7 @@ class EISClient:
                 elif etype == _EI_EVENT_DEVICE_RESUMED:
                     pass  # Device ready for input
 
-                _libei.ei_event_unref(event)
+                _get_libei().ei_event_unref(event)
 
             if self._pointer and self._keyboard:
                 break
@@ -325,15 +336,15 @@ class EISClient:
             raise RuntimeError(msg)
 
         # Start emulating on all devices
-        _libei.ei_device_start_emulating(self._pointer, 0)
+        _get_libei().ei_device_start_emulating(self._pointer, 0)
         if self._keyboard != self._pointer:
-            _libei.ei_device_start_emulating(self._keyboard, 0)
+            _get_libei().ei_device_start_emulating(self._keyboard, 0)
         if self._touch_device and self._touch_device not in (self._pointer, self._keyboard):
-            _libei.ei_device_start_emulating(self._touch_device, 0)
+            _get_libei().ei_device_start_emulating(self._touch_device, 0)
 
     def _bind_seat_capabilities(self, event: int) -> None:
         """Bind to all available capabilities on the seat."""
-        seat = _libei.ei_event_get_seat(event)
+        seat = _get_libei().ei_event_get_seat(event)
 
         bind_list: list[int] = []
         for cap in [
@@ -344,11 +355,11 @@ class EISClient:
             _EI_CAP_BUTTON,
             _EI_CAP_SCROLL,
         ]:
-            if _libei.ei_seat_has_capability(seat, cap):
+            if _get_libei().ei_seat_has_capability(seat, cap):
                 bind_list.append(cap)
 
         # Call variadic ei_seat_bind_capabilities(seat, cap1, ..., NULL)
-        func = _libei.ei_seat_bind_capabilities
+        func = _get_libei().ei_seat_bind_capabilities
         func.restype = None
         args: list[ctypes.c_uint | ctypes.c_void_p] = [ctypes.c_uint(c) for c in bind_list]
         args.append(ctypes.c_void_p(None))  # NULL sentinel
@@ -356,19 +367,19 @@ class EISClient:
 
     def _register_device(self, event: int) -> None:
         """Register a device from a DEVICE_ADDED event."""
-        device = _libei.ei_event_get_device(event)
+        device = _get_libei().ei_event_get_device(event)
 
-        has_abs = _libei.ei_device_has_capability(device, _EI_CAP_POINTER_ABSOLUTE)
-        has_kbd = _libei.ei_device_has_capability(device, _EI_CAP_KEYBOARD)
-        has_touch = _libei.ei_device_has_capability(device, _EI_CAP_TOUCH)
+        has_abs = _get_libei().ei_device_has_capability(device, _EI_CAP_POINTER_ABSOLUTE)
+        has_kbd = _get_libei().ei_device_has_capability(device, _EI_CAP_KEYBOARD)
+        has_touch = _get_libei().ei_device_has_capability(device, _EI_CAP_TOUCH)
 
         # Prefer absolute pointer device
         if has_abs and not self._pointer:
-            self._pointer = _libei.ei_device_ref(device)
+            self._pointer = _get_libei().ei_device_ref(device)
         if has_kbd and not self._keyboard:
-            self._keyboard = _libei.ei_device_ref(device)
+            self._keyboard = _get_libei().ei_device_ref(device)
         if has_touch and not self._touch_device:
-            self._touch_device = _libei.ei_device_ref(device)
+            self._touch_device = _get_libei().ei_device_ref(device)
 
     def _now_us(self) -> int:
         """Current time in microseconds."""
@@ -376,53 +387,53 @@ class EISClient:
 
     def _flush(self) -> None:
         """Dispatch pending events to send data to KWin."""
-        _libei.ei_dispatch(self._ei)
+        _get_libei().ei_dispatch(self._ei)
 
     def pointer_move_absolute(self, x: float, y: float) -> None:
         """Move pointer to absolute coordinates."""
-        _libei.ei_device_pointer_motion_absolute(self._pointer, x, y)
-        _libei.ei_device_frame(self._pointer, self._now_us())
+        _get_libei().ei_device_pointer_motion_absolute(self._pointer, x, y)
+        _get_libei().ei_device_frame(self._pointer, self._now_us())
         self._flush()
 
     def pointer_button(self, button: int, state: int) -> None:
         """Press/release a mouse button (evdev button code)."""
-        _libei.ei_device_button_button(self._pointer, button, state)
-        _libei.ei_device_frame(self._pointer, self._now_us())
+        _get_libei().ei_device_button_button(self._pointer, button, state)
+        _get_libei().ei_device_frame(self._pointer, self._now_us())
         self._flush()
 
     def pointer_scroll(self, dx: float, dy: float) -> None:
         """Scroll by pixel delta."""
-        _libei.ei_device_scroll_delta(self._pointer, dx, dy)
-        _libei.ei_device_frame(self._pointer, self._now_us())
+        _get_libei().ei_device_scroll_delta(self._pointer, dx, dy)
+        _get_libei().ei_device_frame(self._pointer, self._now_us())
         self._flush()
 
     def pointer_scroll_discrete(self, dx: int, dy: int) -> None:
         """Scroll by discrete steps (wheel ticks)."""
-        _libei.ei_device_scroll_discrete(self._pointer, dx, dy)
-        _libei.ei_device_frame(self._pointer, self._now_us())
+        _get_libei().ei_device_scroll_discrete(self._pointer, dx, dy)
+        _get_libei().ei_device_frame(self._pointer, self._now_us())
         self._flush()
 
     def pointer_scroll_stop(self) -> None:
         """Signal end of scroll."""
-        _libei.ei_device_scroll_stop(self._pointer, 1, 1)
-        _libei.ei_device_frame(self._pointer, self._now_us())
+        _get_libei().ei_device_scroll_stop(self._pointer, 1, 1)
+        _get_libei().ei_device_frame(self._pointer, self._now_us())
         self._flush()
 
     def keyboard_key(self, keycode: int, state: int) -> None:
         """Press/release a key (evdev keycode)."""
-        _libei.ei_device_keyboard_key(self._keyboard, keycode, state)
-        _libei.ei_device_frame(self._keyboard, self._now_us())
+        _get_libei().ei_device_keyboard_key(self._keyboard, keycode, state)
+        _get_libei().ei_device_frame(self._keyboard, self._now_us())
         self._flush()
 
     def touch_down(self, x: float, y: float) -> int:
         """Start a new touch at (x, y). Returns a touch ID."""
         device = self._touch_device or self._pointer
-        touch = _libei.ei_device_touch_new(device)
+        touch = _get_libei().ei_device_touch_new(device)
         if not touch:
             msg = "Failed to create touch object"
             raise RuntimeError(msg)
-        _libei.ei_touch_down(touch, x, y)
-        _libei.ei_device_frame(device, self._now_us())
+        _get_libei().ei_touch_down(touch, x, y)
+        _get_libei().ei_device_frame(device, self._now_us())
         self._flush()
 
         touch_id = self._next_touch_id
@@ -437,8 +448,8 @@ class EISClient:
             msg = f"No active touch with ID {touch_id}"
             raise ValueError(msg)
         device = self._touch_device or self._pointer
-        _libei.ei_touch_motion(touch, x, y)
-        _libei.ei_device_frame(device, self._now_us())
+        _get_libei().ei_touch_motion(touch, x, y)
+        _get_libei().ei_device_frame(device, self._now_us())
         self._flush()
 
     def touch_up(self, touch_id: int) -> None:
@@ -448,30 +459,30 @@ class EISClient:
             msg = f"No active touch with ID {touch_id}"
             raise ValueError(msg)
         device = self._touch_device or self._pointer
-        _libei.ei_touch_up(touch)
-        _libei.ei_device_frame(device, self._now_us())
-        _libei.ei_touch_unref(touch)
+        _get_libei().ei_touch_up(touch)
+        _get_libei().ei_device_frame(device, self._now_us())
+        _get_libei().ei_touch_unref(touch)
         self._flush()
 
     def close(self) -> None:
         """Clean up EIS connection."""
         # Release any lingering touches
         for touch in self._active_touches.values():
-            _libei.ei_touch_up(touch)
-            _libei.ei_touch_unref(touch)
+            _get_libei().ei_touch_up(touch)
+            _get_libei().ei_touch_unref(touch)
         self._active_touches.clear()
 
         if self._touch_device and self._touch_device not in (self._pointer, self._keyboard):
-            _libei.ei_device_stop_emulating(self._touch_device)
-            _libei.ei_device_unref(self._touch_device)
+            _get_libei().ei_device_stop_emulating(self._touch_device)
+            _get_libei().ei_device_unref(self._touch_device)
             self._touch_device = 0
         if self._pointer:
-            _libei.ei_device_stop_emulating(self._pointer)
-            _libei.ei_device_unref(self._pointer)
+            _get_libei().ei_device_stop_emulating(self._pointer)
+            _get_libei().ei_device_unref(self._pointer)
             self._pointer = 0
         if self._keyboard and self._keyboard != self._pointer:
-            _libei.ei_device_stop_emulating(self._keyboard)
-            _libei.ei_device_unref(self._keyboard)
+            _get_libei().ei_device_stop_emulating(self._keyboard)
+            _get_libei().ei_device_unref(self._keyboard)
             self._keyboard = 0
 
         if self._eis_iface and self._cookie:
@@ -479,7 +490,7 @@ class EISClient:
                 self._eis_iface.disconnect(dbus.Int32(self._cookie))
 
         if self._ei:
-            _libei.ei_unref(self._ei)
+            _get_libei().ei_unref(self._ei)
             self._ei = 0
 
 

--- a/tests/test_lazy_libei.py
+++ b/tests/test_lazy_libei.py
@@ -1,0 +1,56 @@
+"""Tests for lazy libei loading.
+
+``kwin_mcp.input`` used to load libei eagerly at import time
+(``_libei = _load_libei()`` at module level), so importing the module — and
+with it the whole package: MCP server, CLI — failed on systems without
+``libei.so.1`` installed, even though no EIS input path was touched there.
+The library is now loaded lazily on first use via ``_get_libei()``.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import importlib
+
+import pytest
+
+import kwin_mcp.input as input_module
+
+
+@pytest.fixture(autouse=True)
+def _fresh_module_state():
+    """Re-execute the module around each test for clean module-level state."""
+    importlib.reload(input_module)
+    yield
+    importlib.reload(input_module)
+
+
+def test_import_does_not_load_libei(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Importing the module must not require libei at all."""
+
+    def _no_libei(*args: object, **kwargs: object) -> ctypes.CDLL:
+        raise OSError("libei not available (simulated)")
+
+    monkeypatch.setattr(ctypes, "CDLL", _no_libei)
+    # Re-execute the module with CDLL broken: eager loading would raise
+    # OSError here, lazy loading must complete without touching libei.
+    importlib.reload(input_module)
+
+    assert input_module._libei is None
+
+
+def test_get_libei_loads_lazily_and_caches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_get_libei() loads on first call and returns the same handle after."""
+    sentinel = ctypes.CDLL  # any stable object; never actually used as a library
+    calls: list[int] = []
+
+    def _fake_load() -> ctypes.CDLL:
+        calls.append(1)
+        return sentinel
+
+    monkeypatch.setattr(input_module, "_load_libei", _fake_load)
+
+    assert input_module._libei is None  # nothing loaded at import time
+    assert input_module._get_libei() is sentinel
+    assert input_module._get_libei() is sentinel
+    assert len(calls) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -235,6 +235,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -274,6 +283,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -288,6 +298,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pytest", specifier = ">=9.0.1" },
     { name = "ruff", specifier = ">=0.11.0" },
     { name = "ty", specifier = ">=0.0.1" },
 ]
@@ -315,6 +326,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
 ]
 
 [[package]]
@@ -384,6 +404,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/01/4a/9202e8d11714c1fc5951f2e1ef362f2d7fbc595e1f6717971d5dd750e969/pillow-12.1.1-cp314-cp314t-win32.whl", hash = "sha256:d2912fd8114fc5545aa3a4b5576512f64c55a03f3ebcca4c10194d593d43ea36", size = 6438736, upload-time = "2026-02-11T04:22:46.347Z" },
     { url = "https://files.pythonhosted.org/packages/f3/ca/cbce2327eb9885476b3957b2e82eb12c866a8b16ad77392864ad601022ce/pillow-12.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:4ceb838d4bd9dab43e06c363cab2eebf63846d6a4aeaea283bbdfd8f1a8ed58b", size = 7182894, upload-time = "2026-02-11T04:22:48.114Z" },
     { url = "https://files.pythonhosted.org/packages/ec/d2/de599c95ba0a973b94410477f8bf0b6f0b5e67360eb89bcb1ad365258beb/pillow-12.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:7b03048319bfc6170e93bd60728a1af51d3dd7704935feb228c4d4faab35d334", size = 2546446, upload-time = "2026-02-11T04:22:50.342Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -515,6 +544,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
 name = "pygobject"
 version = "3.54.5"
 source = { registry = "https://pypi.org/simple" }
@@ -535,6 +573,22 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

`input.py` eagerly loads `libei.so.1` at import time (`_libei = _load_libei()` at module level). Importing `kwin_mcp.server` (or anything touching the package) on a system without libei installed raises `OSError: libei.so.1: cannot open shared object file` — even when no input path is used. Concrete impact: CI jobs that only exercise module structure/type-checks fail; packaging checks (`uv build` → import smoke) break on minimal containers.

## Fix

Lazy loading: `_libei: ctypes.CDLL | None = None` + `_get_libei()` called at each use site (mechanical replacement, 53 call sites). First use loads and caches; import never touches the native library.

## Testing

`tests/test_lazy_libei.py` — 2 tests: (1) import with `ctypes.CDLL` broken proves no eager load; (2) repeated `_get_libei()` returns the cached handle (single load). Local: `ruff check/format`, `ty check`, `uv build`, `pytest` — green. In the maintained fork this unblocked the pytest CI job entirely (previously `tests/test_server.py` collection died on the import).